### PR TITLE
fix: keep time entries on their authored day at UTC+12 and beyond

### DIFF
--- a/src/__tests__/storedDayLocalReads.test.ts
+++ b/src/__tests__/storedDayLocalReads.test.ts
@@ -1,0 +1,181 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import moment from 'moment'
+
+vi.mock('@/lib/logger', () => import('@/__tests__/mocks/logger'))
+vi.mock('@/stores/mmkv', () => import('@/__tests__/mocks/mmkv'))
+vi.mock(
+  '@react-native-async-storage/async-storage',
+  () => import('@/__tests__/mocks/asyncStorage')
+)
+
+import useServiceReport from '@/stores/serviceReport'
+import { getMonthsReports } from '@/lib/serviceReport'
+import {
+  isStoredDateOnLocalDay,
+  normalizeDateForStorage,
+  storedDateToLocalDate,
+  storedDayKey,
+} from '@/lib/normalizeDate'
+import { flattenDailyMinutes } from '@/features/profile/lib/profileStats'
+
+const originalTZ = process.env.TZ
+const setTZ = (tz: string) => {
+  process.env.TZ = tz
+}
+
+beforeAll(() => setTZ('Pacific/Auckland'))
+afterAll(() => {
+  vi.useRealTimers()
+  if (originalTZ === undefined) delete process.env.TZ
+  else process.env.TZ = originalTZ
+})
+
+beforeEach(() => {
+  vi.useRealTimers()
+  const s = useServiceReport.getState()
+  s._WARNING_forceDeleteServiceReports()
+  s._WARNING_forceDeleteDayPlans()
+  s._WARNING_forceDeleteRecurringPlans()
+})
+
+// Regression suite for the NZ (UTC≥+12) day-shift report: a stored noon-UTC
+// anchor is already 00:00/01:00 of the *next* local day there, so any
+// local-mode read of `TimeEntry.date` / `DayPlan.date` paints the entry one
+// cell late on the calendar and one day late in day-keyed stats.
+describe('calendar day reads at UTC>=+12', () => {
+  it('a report logged for Aug 19 in NZST lands in the Aug 19 calendar cell, not Aug 20', () => {
+    setTZ('Pacific/Auckland') // August = NZST, UTC+12
+    useServiceReport.getState().addServiceReport({
+      id: 'nz-aug-19',
+      hours: 2,
+      minutes: 0,
+      date: moment('2026-08-19').toDate(), // what the Add Time picker hands over
+    })
+
+    const monthsReports = getMonthsReports(
+      useServiceReport.getState().serviceReports,
+      7,
+      2026
+    )
+    expect(monthsReports).toHaveLength(1)
+
+    // CalendarDay's per-cell filter, keyed by react-native-calendars'
+    // `dateString`.
+    expect(isStoredDateOnLocalDay(monthsReports[0].date, '2026-08-19')).toBe(
+      true
+    )
+    expect(isStoredDateOnLocalDay(monthsReports[0].date, '2026-08-20')).toBe(
+      false
+    )
+  })
+
+  it('a report logged for the last day of July stays on Jul 31 and inside the July bucket', () => {
+    setTZ('Pacific/Auckland')
+    useServiceReport.getState().addServiceReport({
+      id: 'nz-jul-31',
+      hours: 1,
+      minutes: 0,
+      date: moment('2026-07-31').toDate(),
+    })
+
+    const state = useServiceReport.getState()
+    const julyReports = getMonthsReports(state.serviceReports, 6, 2026)
+    expect(julyReports).toHaveLength(1)
+    expect(isStoredDateOnLocalDay(julyReports[0].date, '2026-07-31')).toBe(true)
+
+    // Must NOT leak into August — the user's "vanishing across the month
+    // boundary" symptom was the entry rendering on a local Aug 1 that the
+    // August page (which reads only the August bucket) never receives.
+    expect(getMonthsReports(state.serviceReports, 7, 2026)).toHaveLength(0)
+    expect(isStoredDateOnLocalDay(julyReports[0].date, '2026-08-01')).toBe(
+      false
+    )
+  })
+
+  it('day plans match their authored local day in NZST', () => {
+    setTZ('Pacific/Auckland')
+    useServiceReport.getState().addDayPlan({
+      id: 'nz-plan',
+      date: moment('2026-08-19').toDate(),
+      minutes: 240,
+    })
+
+    const { dayPlans } = useServiceReport.getState()
+    expect(isStoredDateOnLocalDay(dayPlans[0].date, '2026-08-19')).toBe(true)
+    expect(isStoredDateOnLocalDay(dayPlans[0].date, '2026-08-20')).toBe(false)
+  })
+
+  it('seeding the edit form does not advance the stored day (the "+2 days" report)', () => {
+    setTZ('Pacific/Auckland')
+    const stored = normalizeDateForStorage(moment('2026-08-19').toDate())
+
+    // AddTimeScreen seeds its picker from the stored anchor; saving re-runs
+    // normalizeDateForStorage on the picker value. The round trip must be
+    // stable or every edit shifts the entry another day.
+    const pickerValue = storedDateToLocalDate(stored)
+    expect(moment(pickerValue).format('YYYY-MM-DD')).toBe('2026-08-19')
+    expect(normalizeDateForStorage(pickerValue).toISOString()).toBe(
+      stored.toISOString()
+    )
+  })
+
+  it('recognizes a report logged this morning as "today" (widget publisher state)', () => {
+    setTZ('Pacific/Auckland')
+    // Aug 19, 10:00 NZST — a local morning that is still Aug 18 in UTC, the
+    // sharpest edge for mixed-mode day comparison.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-18T22:00:00.000Z'))
+
+    const stored = normalizeDateForStorage(new Date())
+    expect(storedDayKey(stored)).toBe('2026-08-19')
+    expect(isStoredDateOnLocalDay(stored, moment())).toBe(true)
+  })
+
+  it('flattenDailyMinutes keys minutes by the authored local day in NZST', () => {
+    setTZ('Pacific/Auckland')
+    useServiceReport.getState().addServiceReport({
+      id: 'nz-streak',
+      hours: 2,
+      minutes: 0,
+      date: moment('2026-08-19').toDate(),
+    })
+
+    const daily = flattenDailyMinutes(
+      useServiceReport.getState().serviceReports
+    )
+    expect(daily.get('2026-08-19')).toBe(120)
+    expect(daily.get('2026-08-20')).toBeUndefined()
+  })
+
+  it.each([
+    ['Pacific/Auckland (NZDT, UTC+13)', 'Pacific/Auckland', '2026-01-15'],
+    ['Pacific/Kiritimati (UTC+14)', 'Pacific/Kiritimati', '2026-08-19'],
+    ['America/Los_Angeles (UTC-7/-8)', 'America/Los_Angeles', '2026-08-19'],
+    ['UTC', 'UTC', '2026-08-19'],
+  ])('predicate matches the authored day in %s', (_label, tz, day) => {
+    setTZ(tz)
+    const stored = normalizeDateForStorage(moment(day).toDate())
+    expect(storedDayKey(stored)).toBe(day)
+    expect(isStoredDateOnLocalDay(stored, day)).toBe(true)
+    expect(isStoredDateOnLocalDay(stored, moment(day).add(1, 'day'))).toBe(
+      false
+    )
+    expect(isStoredDateOnLocalDay(stored, moment(day).subtract(1, 'day'))).toBe(
+      false
+    )
+
+    const pickerValue = storedDateToLocalDate(stored)
+    expect(moment(pickerValue).format('YYYY-MM-DD')).toBe(day)
+    expect(normalizeDateForStorage(pickerValue).toISOString()).toBe(
+      stored.toISOString()
+    )
+  })
+})

--- a/src/app/widgets/buildCalendar.ts
+++ b/src/app/widgets/buildCalendar.ts
@@ -1,4 +1,5 @@
 import moment from 'moment'
+import { isStoredDateOnLocalDay } from '@/lib/normalizeDate'
 import { DayPlan, TimeEntriesByYear } from '@/types/timeEntry'
 import { Publisher } from '@/types/publisher'
 import { getEntryMode } from '@/lib/publisherCapabilities'
@@ -132,7 +133,7 @@ export function buildCalendar(args: BuildCalendarArgs): WidgetCalendar {
 
     // Reports only live in the current month bucket; skip the cross-month tail.
     const reportsForDay = isCurrentMonth
-      ? monthReports.filter((r) => moment(r.date).isSame(d, 'day'))
+      ? monthReports.filter((r) => isStoredDateOnLocalDay(r.date, d))
       : []
     const wentInService = reportsForDay.length > 0
     const workedMinutes = reportsForDay.reduce(
@@ -140,7 +141,7 @@ export function buildCalendar(args: BuildCalendarArgs): WidgetCalendar {
       0
     )
 
-    const dayPlan = args.dayPlans.find((p) => moment(p.date).isSame(d, 'day'))
+    const dayPlan = args.dayPlans.find((p) => isStoredDateOnLocalDay(p.date, d))
     const recurringPlansForDay = getPlansIntersectingDay(
       dDate,
       args.recurringPlans

--- a/src/app/widgets/buildReport.ts
+++ b/src/app/widgets/buildReport.ts
@@ -1,5 +1,6 @@
 import round from 'lodash/round'
 import moment from 'moment'
+import { isStoredDateOnLocalDay } from '@/lib/normalizeDate'
 import {
   adjustedMinutesForSpecificMonth,
   getDaysLeftInCurrentMonth,
@@ -177,7 +178,7 @@ export function buildReport(args: BuildReportArgs): ReportFields {
   const monthReports = getMonthsReports(args.serviceReports, month, year)
   const hasReportedThisMonth = monthReports.length > 0
   const hasReportedToday = monthReports.some((r) =>
-    moment(r.date).isSame(now, 'day')
+    isStoredDateOnLocalDay(r.date, now)
   )
 
   const adjusted = adjustedMinutesForSpecificMonth(

--- a/src/components/CalendarDay.tsx
+++ b/src/components/CalendarDay.tsx
@@ -8,6 +8,7 @@ import useTheme from '@/contexts/theme'
 import Button from '@/components/ui/Button'
 import useServiceReport from '@/stores/serviceReport'
 import moment from 'moment'
+import { isStoredDateOnLocalDay } from '@/lib/normalizeDate'
 import { DayPlan, TimeEntry } from '@/types/timeEntry'
 import {
   RecurringPlan,
@@ -365,7 +366,7 @@ const CalendarDay = (
     }
 
     return props.monthsReports.filter((report) =>
-      moment(report.date).isSame(props.date?.dateString, 'day')
+      isStoredDateOnLocalDay(report.date, props.date!.dateString)
     )
   }, [props.date, props.monthsReports])
 
@@ -373,7 +374,7 @@ const CalendarDay = (
     () =>
       props.date?.dateString
         ? dayPlans.find((plan) =>
-            moment(plan.date).isSame(props.date?.dateString, 'day')
+            isStoredDateOnLocalDay(plan.date, props.date!.dateString)
           )
         : undefined,
     [dayPlans, props.date]

--- a/src/features/notes-import/lib/notesImportUsage.test.ts
+++ b/src/features/notes-import/lib/notesImportUsage.test.ts
@@ -130,10 +130,13 @@ describe('normalizeNotesImportCredits', () => {
 
   it('treats allowance fields as authoritative despite Supporter status', () => {
     expect(
-      normalizeNotesImportCredits({
-        ...finiteSnapshot,
-        isSupporter: true,
-      })
+      normalizeNotesImportCredits(
+        {
+          ...finiteSnapshot,
+          isSupporter: true,
+        },
+        { now: Date.parse('2026-08-01T00:00:00.000Z') }
+      )
     ).toEqual({ ...finiteSnapshot, isSupporter: true })
 
     expect(

--- a/src/features/plans/components/MonthPlansList.tsx
+++ b/src/features/plans/components/MonthPlansList.tsx
@@ -2,6 +2,7 @@ import { View } from 'react-native'
 import { useMemo } from 'react'
 import { FlashList } from '@shopify/flash-list'
 import moment from 'moment'
+import { isStoredDateOnLocalDay } from '@/lib/normalizeDate'
 import Text from '@/components/ui/MyText'
 import useTheme from '@/contexts/theme'
 import useServiceReport from '@/stores/serviceReport'
@@ -34,7 +35,7 @@ const MonthPlansList = ({ month, year }: MonthPlansListProps) => {
 
       // Check for day plans
       const dayPlan = dayPlans.find((plan) =>
-        moment(plan.date).isSame(currentDate, 'day')
+        isStoredDateOnLocalDay(plan.date, currentDate)
       )
 
       if (dayPlan) {

--- a/src/features/plans/screens/ScheduleScreen.tsx
+++ b/src/features/plans/screens/ScheduleScreen.tsx
@@ -24,7 +24,10 @@ import {
 import { getPeriodTense } from '@/lib/projectedTotalCopy'
 import usePublisher from '@/hooks/usePublisher'
 import useProjectedTotal from '@/hooks/useProjectedTotal'
-import { getStartTimeInMinutes } from '@/lib/normalizeDate'
+import {
+  getStartTimeInMinutes,
+  isStoredDateOnLocalDay,
+} from '@/lib/normalizeDate'
 import { RootStackNavigation } from '@/types/rootStack'
 import { HomeTabStackParamList } from '@/types/homeStack'
 import { DayPlan, TimeEntry } from '@/types/timeEntry'
@@ -105,7 +108,7 @@ const ScheduleScreen = ({ route }: Props) => {
       const dayStartMs = moment(base).date(d).startOf('day').valueOf()
 
       const dayPlansForDay = dayPlans.filter((dp) =>
-        moment(dp.date).isSame(dayDate, 'day')
+        isStoredDateOnLocalDay(dp.date, dayDate)
       )
       for (const plan of dayPlansForDay) {
         items.push({

--- a/src/features/profile/lib/profileStats.ts
+++ b/src/features/profile/lib/profileStats.ts
@@ -1,5 +1,6 @@
 import moment from 'moment'
 import { TimeEntriesByYear } from '@/types/timeEntry'
+import { storedDayKey } from '@/lib/normalizeDate'
 
 const dayKey = (d: moment.Moment) => d.format('YYYY-MM-DD')
 
@@ -11,7 +12,7 @@ export const flattenDailyMinutes = (
   for (const year of Object.values(reports)) {
     for (const month of Object.values(year)) {
       for (const r of month) {
-        const key = dayKey(moment(r.date))
+        const key = storedDayKey(r.date)
         const minutes = (r.hours || 0) * 60 + (r.minutes || 0)
         out.set(key, (out.get(key) || 0) + minutes)
       }

--- a/src/features/service-reports/components/AllDaysList.tsx
+++ b/src/features/service-reports/components/AllDaysList.tsx
@@ -3,6 +3,7 @@ import { useMemo, useRef, useState, useCallback, useEffect } from 'react'
 import { View } from 'react-native'
 import { useNavigation as useRootNavigation } from '@react-navigation/native'
 import moment from 'moment'
+import { isStoredDateOnLocalDay } from '@/lib/normalizeDate'
 
 import useServiceReport from '@/stores/serviceReport'
 import useCategories from '@/stores/categories'
@@ -161,7 +162,7 @@ const AllDaysList = ({ month, year }: AllDaysListProps) => {
       const day = moment(base).date(d)
       const dayDate = day.toDate()
       const reportsForDay = thisMonthsReports.filter((r) =>
-        moment(r.date).isSame(day, 'day')
+        isStoredDateOnLocalDay(r.date, day)
       )
 
       const totalMinutes = reportsForDay.reduce(
@@ -174,7 +175,7 @@ const AllDaysList = ({ month, year }: AllDaysListProps) => {
           : formatMinutes(totalMinutes, timeDisplayFormat).formatted
 
       const dayPlanForDay = dayPlans.find((dp) =>
-        moment(dp.date).isSame(day, 'day')
+        isStoredDateOnLocalDay(dp.date, day)
       )
       const recurringPlansForDay = getPlansIntersectingDay(
         dayDate,

--- a/src/features/service-reports/components/DayHistoryView.tsx
+++ b/src/features/service-reports/components/DayHistoryView.tsx
@@ -5,6 +5,7 @@ import Text from '@/components/ui/MyText'
 import i18n from '@/lib/locales'
 import useTheme from '@/contexts/theme'
 import moment from 'moment'
+import { isStoredDateOnLocalDay } from '@/lib/normalizeDate'
 import { formatDate } from '@/lib/dates'
 import { FlashList } from '@shopify/flash-list'
 import { TimeEntry, DayPlan } from '@/types/timeEntry'
@@ -82,7 +83,7 @@ const DayHistoryView: React.FC<DayHistoryViewProps> = ({
   const { dayPlans, recurringPlans } = useServiceReport()
 
   const thisDaysReports = useMemo(
-    () => serviceReports?.filter((r) => moment(r.date).isSame(date, 'day')),
+    () => serviceReports?.filter((r) => isStoredDateOnLocalDay(r.date, date)),
     [date, serviceReports]
   )
 
@@ -97,7 +98,7 @@ const DayHistoryView: React.FC<DayHistoryViewProps> = ({
   }, [thisDaysReports])
 
   const dayPlansForToday = useMemo(() => {
-    return dayPlans.filter((dp) => moment(dp.date).isSame(date, 'day'))
+    return dayPlans.filter((dp) => isStoredDateOnLocalDay(dp.date, date))
   }, [dayPlans, date])
 
   const recurringPlansForToday = useMemo(() => {
@@ -124,7 +125,7 @@ const DayHistoryView: React.FC<DayHistoryViewProps> = ({
   }, [date, dayPlansForToday, recurringPlansForToday])
 
   const goalMinutes = useMemo(() => {
-    const dayPlan = dayPlans.find((dp) => moment(dp.date).isSame(date, 'day'))
+    const dayPlan = dayPlans.find((dp) => isStoredDateOnLocalDay(dp.date, date))
 
     // Get the highest recurring plan for the day, but use effective minutes (with overrides)
     const highestRecurringPlanForDay = recurringPlansForToday

--- a/src/features/service-reports/components/MonthReport.tsx
+++ b/src/features/service-reports/components/MonthReport.tsx
@@ -37,6 +37,7 @@ import {
   useNavigation,
 } from '@react-navigation/native'
 import moment from 'moment'
+import { momentStoredDate } from '@/lib/normalizeDate'
 import GoalProgressStats from '@/features/service-reports/components/GoalProgressStats'
 import { RootStackNavigation } from '@/types/rootStack'
 import { HomeTabStackNavigation } from '@/types/homeStack'
@@ -207,7 +208,7 @@ const MonthReport = ({
     const latest = monthsReports.reduce((prev, curr) =>
       moment(curr.date).isAfter(prev.date) ? curr : prev
     )
-    return moment(latest.date)
+    return momentStoredDate(latest.date)
   }, [monthsReports])
 
   const ldcMinutes = useMemo(

--- a/src/features/service-reports/components/TimeReportRow.tsx
+++ b/src/features/service-reports/components/TimeReportRow.tsx
@@ -12,6 +12,7 @@ import i18n from '@/lib/locales'
 import useServiceReport from '@/stores/serviceReport'
 import Text from '@/components/ui/MyText'
 import { formatDate } from '@/lib/dates'
+import { momentStoredDate } from '@/lib/normalizeDate'
 import IconButton from '@/components/ui/IconButton'
 import { useCallback } from 'react'
 import Button from '@/components/ui/Button'
@@ -168,7 +169,7 @@ const TimeReportRow = ({ report, onPress }: TimeReportRowProps) => {
               numberOfLines={1}
               ellipsizeMode='tail'
             >
-              {formatDate(report.date)}
+              {formatDate(momentStoredDate(report.date))}
             </Text>
           </View>
           <Text

--- a/src/features/service-reports/screens/AddTimeScreen.tsx
+++ b/src/features/service-reports/screens/AddTimeScreen.tsx
@@ -10,6 +10,7 @@ import useServiceReport from '@/stores/serviceReport'
 import * as Crypto from 'expo-crypto'
 import { DateTimePickerEvent } from '@react-native-community/datetimepicker'
 import moment from 'moment'
+import { storedDateToLocalDate } from '@/lib/normalizeDate'
 import { TimeEntry } from '@/types/timeEntry'
 import { useNavigation } from '@react-navigation/native'
 import i18n from '@/lib/locales'
@@ -96,9 +97,9 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
     hours: existingServiceReport?.report.hours || route.params?.hours || 0,
     minutes:
       existingServiceReport?.report.minutes ?? (route.params?.minutes || 0),
-    date: moment(
-      existingServiceReport?.report.date ?? route.params?.date
-    ).toDate(),
+    date: existingServiceReport
+      ? storedDateToLocalDate(existingServiceReport.report.date)
+      : moment(route.params?.date).toDate(),
     credit: existingServiceReport?.report.credit ?? false,
     categoryId: existingServiceReport?.report.categoryId,
     note: existingServiceReport?.report.note ?? '',

--- a/src/lib/normalizeDate.ts
+++ b/src/lib/normalizeDate.ts
@@ -78,6 +78,29 @@ export const momentStoredDate = (date: Date | string): moment.Moment =>
 export const localDayFromUtcCursor = (cursor: moment.Moment): Date =>
   new Date(cursor.year(), cursor.month(), cursor.date(), 12)
 
+/** The `YYYY-MM-DD` calendar day carried by a stored noon-UTC anchor. */
+export const storedDayKey = (date: Date | string): string =>
+  momentStoredDate(date).format('YYYY-MM-DD')
+
+/**
+ * True when a stored calendar-day anchor falls on the given local calendar day.
+ * `localDay` expresses a day in _local_ mode — a `YYYY-MM-DD` string (e.g.
+ * react-native-calendars' `dateString`), a local-mode Date, or a local-mode
+ * moment cursor. Never pass another stored anchor as `localDay`; compare
+ * `storedDayKey`s instead.
+ */
+export const isStoredDateOnLocalDay = (
+  stored: Date | string,
+  localDay: Date | string | moment.Moment
+): boolean => storedDayKey(stored) === moment(localDay).format('YYYY-MM-DD')
+
+/**
+ * Converts a stored calendar-day anchor into a local-mode Date carrying the
+ * same calendar day, for date-picker `value` props and local-mode formatting.
+ */
+export const storedDateToLocalDate = (date: Date | string): Date =>
+  localDayFromUtcCursor(momentStoredDate(date))
+
 /** Normalize every Date field on a RecurringPlan to noon-UTC anchor. */
 export const normalizeRecurringPlan = (plan: RecurringPlan): RecurringPlan => ({
   ...plan,


### PR DESCRIPTION
Routes all calendar day-identity reads of stored noon-UTC dates through new `normalizeDate` helpers (UTC-mode day keys) instead of local-mode `moment()`: month calendar cells, day sheet, all-days list, report rows, widgets, streak stats, and the Add Time edit-form seeding. At UTC≥+12 (NZ) entries and plans rendered one day late, vanished across month boundaries, and each edit advanced the stored day by one; no visible change for offsets west of UTC+12. Includes a `TZ=Pacific/Auckland` regression suite, and pins the clock in a notes-import test that had rotted past its fixture window.

ref #261, ref #309

- [x] HITL: on a simulator set to Auckland (UTC+12), log a report for today and confirm it lands on today's calendar cell.