### PR TITLE
fix: recover from an App Attest key Apple refuses to sign with

### DIFF
--- a/modules/app-attest/errorCodes.test.ts
+++ b/modules/app-attest/errorCodes.test.ts
@@ -20,6 +20,7 @@ const uncodedRejection = (token: string): Error =>
 
 const CASES: [string, AppAttestErrorCode][] = [
   ['APP_ATTEST_UNSUPPORTED', 'unsupported'],
+  ['APP_ATTEST_INVALID_ARGUMENT', 'invalidArgument'],
   ['APP_ATTEST_INVALID_INPUT', 'invalidInput'],
   ['APP_ATTEST_INVALID_KEY', 'invalidKey'],
   ['APP_ATTEST_SERVER_UNAVAILABLE', 'serverUnavailable'],
@@ -63,6 +64,15 @@ describe('codeFromNativeError', () => {
         )
       )
     ).toBe('invalidKey')
+  })
+
+  it('keeps our own precondition failure distinct from Apple invalidInput', () => {
+    expect(
+      codeFromNativeError(codedRejection('APP_ATTEST_INVALID_ARGUMENT'))
+    ).toBe('invalidArgument')
+    expect(
+      codeFromNativeError(codedRejection('APP_ATTEST_INVALID_INPUT'))
+    ).toBe('invalidInput')
   })
 
   it('prefers the code property over a conflicting message token', () => {

--- a/modules/app-attest/errorCodes.ts
+++ b/modules/app-attest/errorCodes.ts
@@ -8,6 +8,9 @@
 
 export type AppAttestErrorCode =
   | 'unsupported'
+  /** This module rejected the arguments before Apple saw them; never a dead key. */
+  | 'invalidArgument'
+  /** Apple returned `DCError.invalidInput` for arguments we already validated. */
   | 'invalidInput'
   | 'invalidKey'
   | 'serverUnavailable'
@@ -31,6 +34,7 @@ export class AppAttestError extends Error {
  */
 const NATIVE_TOKENS = {
   APP_ATTEST_UNSUPPORTED: 'unsupported',
+  APP_ATTEST_INVALID_ARGUMENT: 'invalidArgument',
   APP_ATTEST_INVALID_INPUT: 'invalidInput',
   APP_ATTEST_INVALID_KEY: 'invalidKey',
   APP_ATTEST_SERVER_UNAVAILABLE: 'serverUnavailable',

--- a/modules/app-attest/ios/AppAttestModule.swift
+++ b/modules/app-attest/ios/AppAttestModule.swift
@@ -14,6 +14,9 @@ import Foundation
 public class AppAttestModule: Module {
   private enum Code {
     static let unsupported = "APP_ATTEST_UNSUPPORTED"
+    /// This module rejected the arguments before calling Apple.
+    static let invalidArgument = "APP_ATTEST_INVALID_ARGUMENT"
+    /// Apple returned `DCError.invalidInput`.
     static let invalidInput = "APP_ATTEST_INVALID_INPUT"
     static let invalidKey = "APP_ATTEST_INVALID_KEY"
     static let serverUnavailable = "APP_ATTEST_SERVER_UNAVAILABLE"
@@ -58,7 +61,7 @@ public class AppAttestModule: Module {
       guard !keyId.isEmpty,
             let hash = Data(base64Encoded: clientDataHashBase64),
             hash.count == 32 else {
-        self.reject(promise, code: Code.invalidInput)
+        self.reject(promise, code: Code.invalidArgument)
         return
       }
       DCAppAttestService.shared.attestKey(keyId, clientDataHash: hash) {
@@ -84,7 +87,7 @@ public class AppAttestModule: Module {
       guard !keyId.isEmpty,
             let hash = Data(base64Encoded: clientDataHashBase64),
             hash.count == 32 else {
-        self.reject(promise, code: Code.invalidInput)
+        self.reject(promise, code: Code.invalidArgument)
         return
       }
       DCAppAttestService.shared.generateAssertion(keyId, clientDataHash: hash) {

--- a/src/features/notes-import/lib/notesImportAppAttest.test.ts
+++ b/src/features/notes-import/lib/notesImportAppAttest.test.ts
@@ -1549,6 +1549,65 @@ describe('Notes Import App Attest', () => {
     ).toHaveLength(1)
   })
 
+  it('performs one controlled recovery after native invalidInput', async () => {
+    // The adapter validates the key id and hash before Apple sees them, so an
+    // invalidInput surfacing here means Apple rejected the key id itself.
+    const invalidInput = { nativeCode: 'invalidInput' as const }
+    let assertions = 0
+    const harness = createHarness({
+      activeKeyId: 'apple-rejected-key',
+      recoveryToken: 'enrolled-recovery-token',
+      generateAssertion: async () => {
+        if (assertions++ === 0) throw invalidInput
+        return 'assertion'
+      },
+      classifyError: (error) =>
+        error === invalidInput ? 'invalidInput' : null,
+      post: ({ endpoint }) =>
+        endpoint === 'challenge' ? { challenge: 'challenge' } : { ok: true },
+    })
+
+    await harness.module.post({
+      endpoint: 'kickoff',
+      payload: REQUEST_PAYLOAD,
+      contentHash: CONTENT_HASH,
+    })
+
+    expect(harness.generateKey).toHaveBeenCalledTimes(1)
+    expect(harness.secure.activeKeyId).toMatch(/^generated-key-/)
+    expect(
+      harness.posts.filter((call) => call.endpoint === 'kickoff')
+    ).toHaveLength(1)
+  })
+
+  it('never rotates the key for a local invalidArgument failure', async () => {
+    // Our own precondition failure is a caller bug. Rotating keys would not fix
+    // it, and would burn an App Attest key on every attempt.
+    const invalidArgument = { nativeCode: 'invalidArgument' as const }
+    const harness = createHarness({
+      activeKeyId: 'healthy-key',
+      recoveryToken: 'enrolled-recovery-token',
+      generateAssertion: async () => {
+        throw invalidArgument
+      },
+      classifyError: (error) =>
+        error === invalidArgument ? 'invalidArgument' : null,
+      post: ({ endpoint }) =>
+        endpoint === 'challenge' ? { challenge: 'challenge' } : { ok: true },
+    })
+
+    await expect(
+      harness.module.post({
+        endpoint: 'kickoff',
+        payload: REQUEST_PAYLOAD,
+        contentHash: CONTENT_HASH,
+      })
+    ).rejects.toMatchObject({ code: 'invalidArgument' })
+
+    expect(harness.generateKey).not.toHaveBeenCalled()
+    expect(harness.secure.activeKeyId).toBe('healthy-key')
+  })
+
   it('performs one controlled recovery for typed server key_not_active', async () => {
     let kickoffAttempts = 0
     const harness = createHarness({

--- a/src/features/notes-import/lib/notesImportAppAttest.ts
+++ b/src/features/notes-import/lib/notesImportAppAttest.ts
@@ -9,6 +9,7 @@ export type NotesImportProtectedEndpoint = 'kickoff' | 'legacy'
 
 export type AppAttestNativeFailureCode =
   | 'unsupported'
+  | 'invalidArgument'
   | 'invalidInput'
   | 'invalidKey'
   | 'serverUnavailable'
@@ -17,6 +18,7 @@ export type AppAttestNativeFailureCode =
 
 export type NotesImportAppAttestErrorCode =
   | 'unsupported'
+  | 'invalidArgument'
   | 'invalidInput'
   | 'invalidKey'
   | 'serverUnavailable'
@@ -629,6 +631,7 @@ const nativeFailureToErrorCode = (
 ): NotesImportAppAttestErrorCode => {
   switch (code) {
     case 'unsupported':
+    case 'invalidArgument':
     case 'invalidInput':
     case 'invalidKey':
     case 'serverUnavailable':
@@ -638,6 +641,23 @@ const nativeFailureToErrorCode = (
       return 'nativeUnknown'
   }
 }
+
+/**
+ * Whether a native failure means the locally stored key can no longer produce
+ * assertions, so the only way forward is re-registering under the recovery
+ * credential.
+ *
+ * `invalidKey` is Apple naming that outright. `invalidInput` needs the same
+ * treatment because the adapter validates both arguments before Apple ever sees
+ * them — a non-empty key id and a hash it decoded to exactly 32 bytes — and
+ * emits `invalidArgument` when that check fails. So an `invalidInput` reaching
+ * here is Apple objecting to arguments we already know are well formed, and the
+ * key id is the only one it can be objecting to. `invalidArgument` is
+ * deliberately excluded: that is a caller bug, and rotating keys would neither
+ * fix it nor stop it recurring.
+ */
+const isDeadKeyFailure = (code: NotesImportAppAttestErrorCode): boolean =>
+  code === 'invalidKey' || code === 'invalidInput'
 
 const httpAuthError = (
   error: NotesImportAppAttestHttpError
@@ -1539,7 +1559,7 @@ export const createNotesImportAppAttest = (
     } catch (error) {
       if (
         error instanceof NotesImportAppAttestError &&
-        error.code === 'invalidKey'
+        isDeadKeyFailure(error.code)
       ) {
         // Enrollment may have committed before its response was lost and the app
         // was then reinstalled. Try a token that predates this enrollment once;
@@ -1835,7 +1855,7 @@ export const createNotesImportAppAttest = (
           if (
             input.allowRecovery &&
             error instanceof NotesImportAppAttestError &&
-            error.code === 'invalidKey'
+            isDeadKeyFailure(error.code)
           ) {
             return { kind: 'recover' }
           }


### PR DESCRIPTION
Follow-up to #440, which unmasked the real error: a TestFlight install reports `invalidInput` on the assertion step with a fully registered key and a present recovery token, leaving it permanently unable to authorize. `invalidInput` conflated two unrelated failures — the adapter rejecting the arguments itself, and Apple returning `DCError.invalidInput` — so nothing downstream could tell a caller bug from a dead key. Local precondition failures now emit their own code, and Apple's `invalidInput` joins `invalidKey` as a trigger for the existing bounded recovery path, which re-enrolls under the recovery credential and preserves account identity and credits.

Requires a new native build. Whichever of the two codes the next diagnostics run reports also settles the diagnosis the conflated code was preventing.