### PR TITLE
feat: gate Notes Import behind the proxy's minimum app version

### DIFF
--- a/docs/notes-import-min-version.md
+++ b/docs/notes-import-min-version.md
@@ -1,0 +1,33 @@
+# Notes Import minimum app version
+
+`GET /notes-import/status` (ww-api) can advertise `minAppVersion`
+(`major.minor.patch`). When this build's `Constants.expoConfig.version`
+(`app.config.ts`) is below it, the app treats Notes Import as unavailable with
+the client-synthesized reason `version_below_min`:
+
+- the composer text input is disabled and the pinned banner explains the
+  version gap with an **Update** button that opens the App Store
+  (`links.appStore`);
+- the Settings → App row is disabled with "Update WitnessWork to use Notes
+  Import.";
+- Paywall/Help allowance copy is unaffected.
+
+Gate logic: `src/features/notes-import/lib/notesImportVersionGate.ts`; wiring
+in `hooks/useNotesImportAvailability.ts`. It is **fail-open** — no floor, an
+unparseable floor, or a failed probe never disables anything. The floor wins
+over the proxy kill-switch because it's the one state the user can fix.
+
+The worker does not reject requests from old builds; this is UX-only.
+
+## When to bump
+
+After deploying a ww-api change older builds can't handle (request/response
+contract break), set the floor to the first app version that supports it:
+
+```bash
+# in ~/dev/ww-api
+wrangler kv key put --binding NOTES_KV notes-import:min-version '{"minVersion":"1.42.0"}'            # production
+wrangler kv key put --binding NOTES_KV notes-import:min-version '{"minVersion":"1.42.0"}' --env dev  # development
+```
+
+Edge-cached for 60 s. See `AGENTS.md` in ww-api for the full runbook.

--- a/src/features/notes-import/hooks/useNotesImportAvailability.ts
+++ b/src/features/notes-import/hooks/useNotesImportAvailability.ts
@@ -1,7 +1,12 @@
 import { useEffect, useState } from 'react'
+import Constants from 'expo-constants'
 import { create } from 'zustand'
 import { getNotesImportStatus } from '@/features/notes-import/lib/notesImportClient'
 import type { NotesImportPublicSchedule } from '@/features/notes-import/lib/notesImportUsage'
+import {
+  notesImportUpdateRequired,
+  type NotesImportUpdateRequired,
+} from '@/features/notes-import/lib/notesImportVersionGate'
 
 export interface NotesImportAvailability {
   /** False only once the proxy definitively reports the feature is down. */
@@ -10,6 +15,11 @@ export interface NotesImportAvailability {
   reason: string | null
   /** Fresh public allowance schedule held in memory for this app session only. */
   schedule: NotesImportPublicSchedule | null
+  /**
+   * Set when this build is below the proxy's advertised minimum app version.
+   * `available` is false and `reason` is `'version_below_min'` in that case.
+   */
+  updateRequired: NotesImportUpdateRequired | null
   loading: boolean
 }
 
@@ -28,18 +38,48 @@ const useAvailabilityStore = create<AvailabilityStore>((set) => ({
   available: true,
   reason: null,
   schedule: null,
+  updateRequired: null,
   loading: true,
 
   probe: async () => {
     const probe = ++latestProbe
     // Access remains fail-open, but schedule claims disappear while this fresh
     // probe is pending (including when another surface mounts later).
-    set({ available: true, reason: null, schedule: null, loading: true })
+    set({
+      available: true,
+      reason: null,
+      schedule: null,
+      updateRequired: null,
+      loading: true,
+    })
     const status = await getNotesImportStatus().catch(() => null)
     if (probe !== latestProbe) return
 
     if (!status) {
-      set({ available: true, reason: null, schedule: null, loading: false })
+      set({
+        available: true,
+        reason: null,
+        schedule: null,
+        updateRequired: null,
+        loading: false,
+      })
+      return
+    }
+    // The version floor wins over every other state: it is the one condition
+    // the user can resolve themselves, and an update is required regardless of
+    // whether the proxy is also down right now.
+    const updateRequired = notesImportUpdateRequired(
+      Constants.expoConfig?.version,
+      status.minAppVersion
+    )
+    if (updateRequired) {
+      set({
+        available: false,
+        reason: 'version_below_min',
+        schedule: null,
+        updateRequired,
+        loading: false,
+      })
       return
     }
     if (!status.available) {
@@ -47,6 +87,7 @@ const useAvailabilityStore = create<AvailabilityStore>((set) => ({
         available: false,
         reason: status.reason ?? null,
         schedule: null,
+        updateRequired: null,
         loading: false,
       })
       return
@@ -55,6 +96,7 @@ const useAvailabilityStore = create<AvailabilityStore>((set) => ({
       available: true,
       reason: null,
       schedule: status.limits,
+      updateRequired: null,
       loading: false,
     })
   },
@@ -70,6 +112,7 @@ export const useNotesImportAvailability = (): NotesImportAvailability => {
   const available = useAvailabilityStore((state) => state.available)
   const reason = useAvailabilityStore((state) => state.reason)
   const schedule = useAvailabilityStore((state) => state.schedule)
+  const updateRequired = useAvailabilityStore((state) => state.updateRequired)
   const loading = useAvailabilityStore((state) => state.loading)
   const probe = useAvailabilityStore((state) => state.probe)
 
@@ -89,6 +132,7 @@ export const useNotesImportAvailability = (): NotesImportAvailability => {
     available: pending ? true : available,
     reason: pending ? null : reason,
     schedule: pending ? null : schedule,
+    updateRequired: pending ? null : updateRequired,
     loading: pending,
   }
 }

--- a/src/features/notes-import/lib/notesImportClient.ts
+++ b/src/features/notes-import/lib/notesImportClient.ts
@@ -120,7 +120,15 @@ export class NotesImportClientError extends Error {
   }
 }
 
-export type NotesImportUnavailableReason = 'disabled' | 'no_provider'
+/**
+ * `disabled` / `no_provider` come from the proxy; `version_below_min` is
+ * synthesized client-side when this build is under the advertised
+ * `minAppVersion` floor.
+ */
+export type NotesImportUnavailableReason =
+  | 'disabled'
+  | 'no_provider'
+  | 'version_below_min'
 export type { NotesImportStatus } from '@/features/notes-import/lib/notesImportUsage'
 
 /**

--- a/src/features/notes-import/lib/notesImportMessages.test.ts
+++ b/src/features/notes-import/lib/notesImportMessages.test.ts
@@ -70,6 +70,7 @@ describe('unavailableDetail', () => {
   it('suppresses machine reason codes', () => {
     expect(unavailableDetail('disabled')).toBeUndefined()
     expect(unavailableDetail('no_provider')).toBeUndefined()
+    expect(unavailableDetail('version_below_min')).toBeUndefined()
   })
 
   it('treats empty/whitespace/nullish reasons as no detail', () => {

--- a/src/features/notes-import/lib/notesImportMessages.ts
+++ b/src/features/notes-import/lib/notesImportMessages.ts
@@ -29,7 +29,11 @@ export const errorMessageKey = (code: NotesImportErrorCode): string => {
 }
 
 /** Machine reason codes the proxy emits; everything else is operator free text. */
-const MACHINE_UNAVAILABLE_REASONS = new Set(['disabled', 'no_provider'])
+const MACHINE_UNAVAILABLE_REASONS = new Set([
+  'disabled',
+  'no_provider',
+  'version_below_min',
+])
 
 /**
  * The operator-supplied detail to show beneath the generic "unavailable"

--- a/src/features/notes-import/lib/notesImportUsage.test.ts
+++ b/src/features/notes-import/lib/notesImportUsage.test.ts
@@ -189,6 +189,40 @@ describe('normalizeNotesImportStatus', () => {
     ).toEqual({ available: false, reason: 'maintenance' })
   })
 
+  it('carries a well-formed minAppVersion on either state', () => {
+    expect(
+      normalizeNotesImportStatus({
+        available: true,
+        limits,
+        minAppVersion: '1.42.0',
+      })
+    ).toEqual({ available: true, limits, minAppVersion: '1.42.0' })
+    expect(
+      normalizeNotesImportStatus({
+        available: false,
+        reason: 'disabled',
+        minAppVersion: '1.42.0',
+      })
+    ).toEqual({ available: false, reason: 'disabled', minAppVersion: '1.42.0' })
+  })
+
+  it('drops a malformed minAppVersion without rejecting the status', () => {
+    expect(
+      normalizeNotesImportStatus({
+        available: true,
+        limits,
+        minAppVersion: 'v1.42',
+      })
+    ).toEqual({ available: true, limits })
+    expect(
+      normalizeNotesImportStatus({
+        available: true,
+        limits,
+        minAppVersion: 142,
+      })
+    ).toEqual({ available: true, limits })
+  })
+
   it.each([
     ['missing limits', { available: true }],
     [

--- a/src/features/notes-import/lib/notesImportUsage.ts
+++ b/src/features/notes-import/lib/notesImportUsage.ts
@@ -37,9 +37,34 @@ export interface NotesImportPublicSchedule {
   windowDays: number
 }
 
-export type NotesImportStatus =
-  | { available: true; limits: NotesImportPublicSchedule }
-  | { available: false; reason?: string }
+/**
+ * Optional minimum app version (`major.minor.patch`) the proxy advertises on
+ * every status response. Absent when no floor is configured.
+ */
+interface NotesImportStatusVersionFloor {
+  minAppVersion?: string
+}
+
+export type NotesImportStatus = NotesImportStatusVersionFloor &
+  (
+    | { available: true; limits: NotesImportPublicSchedule }
+    | { available: false; reason?: string }
+  )
+
+const MIN_APP_VERSION_PATTERN = /^\d+\.\d+\.\d+$/
+
+/**
+ * A malformed `minAppVersion` is dropped (fail open) rather than rejecting the
+ * whole status payload — the floor is advisory and must never take the
+ * allowance schedule or availability down with it.
+ */
+const statusVersionFloor = (
+  value: Record<string, unknown>
+): NotesImportStatusVersionFloor =>
+  typeof value.minAppVersion === 'string' &&
+  MIN_APP_VERSION_PATTERN.test(value.minAppVersion)
+    ? { minAppVersion: value.minAppVersion }
+    : {}
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -83,9 +108,12 @@ export const normalizeNotesImportStatus = (
     if (value.reason !== undefined && typeof value.reason !== 'string') {
       return null
     }
-    return value.reason === undefined
-      ? { available: false }
-      : { available: false, reason: value.reason }
+    return {
+      ...statusVersionFloor(value),
+      ...(value.reason === undefined
+        ? { available: false as const }
+        : { available: false as const, reason: value.reason }),
+    }
   }
 
   const limits = value.limits
@@ -105,6 +133,7 @@ export const normalizeNotesImportStatus = (
   }
 
   return {
+    ...statusVersionFloor(value),
     available: true,
     limits: {
       imports: {

--- a/src/features/notes-import/lib/notesImportVersionGate.test.ts
+++ b/src/features/notes-import/lib/notesImportVersionGate.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { notesImportUpdateRequired } from '@/features/notes-import/lib/notesImportVersionGate'
+
+describe('notesImportUpdateRequired', () => {
+  it('gates a build below the floor', () => {
+    expect(notesImportUpdateRequired('1.41.1', '1.42.0')).toEqual({
+      currentVersion: '1.41.1',
+      minVersion: '1.42.0',
+    })
+  })
+
+  it('allows a build at or above the floor', () => {
+    expect(notesImportUpdateRequired('1.42.0', '1.42.0')).toBeNull()
+    expect(notesImportUpdateRequired('1.42.1', '1.42.0')).toBeNull()
+    expect(notesImportUpdateRequired('2.0.0', '1.42.0')).toBeNull()
+  })
+
+  it('compares numerically, not lexically', () => {
+    expect(notesImportUpdateRequired('1.10.0', '1.9.0')).toBeNull()
+    expect(notesImportUpdateRequired('1.9.0', '1.10.0')).not.toBeNull()
+  })
+
+  it('fails open when no floor is advertised', () => {
+    expect(notesImportUpdateRequired('1.41.1', undefined)).toBeNull()
+    expect(notesImportUpdateRequired('1.41.1', null)).toBeNull()
+  })
+
+  it('fails open when either version is unparseable', () => {
+    expect(notesImportUpdateRequired(undefined, '1.42.0')).toBeNull()
+    expect(notesImportUpdateRequired('dev', '1.42.0')).toBeNull()
+    expect(notesImportUpdateRequired('1.41.1', 'latest')).toBeNull()
+  })
+})

--- a/src/features/notes-import/lib/notesImportVersionGate.ts
+++ b/src/features/notes-import/lib/notesImportVersionGate.ts
@@ -1,0 +1,26 @@
+import semver from 'semver'
+
+export interface NotesImportUpdateRequired {
+  /** The running app's `app.config.ts` version. */
+  currentVersion: string
+  /** The floor the proxy advertised. */
+  minVersion: string
+}
+
+/**
+ * Decides whether this build is too old for Notes Import. Fail open: any
+ * missing or unparseable version (no floor configured, dev build without a
+ * version, garbage from the wire) means "not gated" — the proxy enforces
+ * nothing server-side, so a false positive here would lock a working feature.
+ */
+export const notesImportUpdateRequired = (
+  currentVersion: string | null | undefined,
+  minVersion: string | null | undefined
+): NotesImportUpdateRequired | null => {
+  const current = semver.valid(currentVersion ?? null)
+  const min = semver.valid(minVersion ?? null)
+  if (!current || !min) return null
+  return semver.lt(current, min)
+    ? { currentVersion: current, minVersion: min }
+    : null
+}

--- a/src/features/notes-import/screens/NotesImportComposerScreen.tsx
+++ b/src/features/notes-import/screens/NotesImportComposerScreen.tsx
@@ -45,6 +45,8 @@ import ActionButton from '@/components/ui/ActionButton'
 import useTheme from '@/contexts/theme'
 import i18n from '@/lib/locales'
 import { formatDate } from '@/lib/dates'
+import { openURL } from '@/lib/links'
+import links from '@/constants/links'
 import type { RootStackNavigation, RootStackParamList } from '@/types/rootStack'
 import { useNotesImportManager } from '@/features/notes-import/hooks/useNotesImportManager'
 import { useNotesImportAvailability } from '@/features/notes-import/hooks/useNotesImportAvailability'
@@ -684,11 +686,15 @@ const NotesImportComposerScreen = ({ renderSupporterCta }: Props) => {
 
   // Pinned top-of-screen notice when the proxy reports the feature is down,
   // appending the operator's detail (e.g. a maintenance window) when present.
+  // When this build is under the proxy's minimum app version the message
+  // explains the version gap instead and offers an App Store jump — the only
+  // unavailable state the user can fix themselves.
   const unavailableBanner = () => {
     const detail = unavailableDetail(availability.reason)
+    const updateRequired = availability.updateRequired
     return (
       <View style={{ paddingHorizontal: 15, paddingTop: 12 }}>
-        <Card style={{ backgroundColor: theme.colors.error }}>
+        <Card style={{ backgroundColor: theme.colors.error, gap: 12 }}>
           <View
             style={{ flexDirection: 'row', gap: 12, alignItems: 'flex-start' }}
           >
@@ -706,11 +712,38 @@ const NotesImportComposerScreen = ({ renderSupporterCta }: Props) => {
                 lineHeight: 20,
               }}
             >
-              {detail
-                ? i18n.t('notesImport_unavailableBannerDetail', { detail })
-                : i18n.t('notesImport_unavailableBanner')}
+              {updateRequired
+                ? i18n.t('notesImport_updateRequiredBanner', {
+                    current: updateRequired.currentVersion,
+                    min: updateRequired.minVersion,
+                  })
+                : detail
+                  ? i18n.t('notesImport_unavailableBannerDetail', { detail })
+                  : i18n.t('notesImport_unavailableBanner')}
             </Text>
           </View>
+          {updateRequired && (
+            <Button
+              onPress={() => openURL(links.appStore)}
+              style={{
+                alignSelf: 'flex-start',
+                backgroundColor: '#fff',
+                borderRadius: theme.numbers.borderRadiusSm,
+                paddingVertical: 8,
+                paddingHorizontal: 16,
+                marginLeft: 30,
+              }}
+            >
+              <Text
+                style={{
+                  color: theme.colors.error,
+                  fontFamily: theme.fonts.bold,
+                }}
+              >
+                {i18n.t('update')}
+              </Text>
+            </Button>
+          )}
         </Card>
       </View>
     )

--- a/src/features/settings/components/sections/App.tsx
+++ b/src/features/settings/components/sections/App.tsx
@@ -51,7 +51,9 @@ const AppSection = ({ handleNavigate }: SettingsSectionProps) => {
           sublabel={
             notesImport.available
               ? undefined
-              : i18n.t('notesImport_unavailable')
+              : notesImport.updateRequired
+                ? i18n.t('notesImport_updateRequired')
+                : i18n.t('notesImport_unavailable')
           }
           onPress={() => handleNavigate('NotesImportComposer')}
         >

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1136,6 +1136,8 @@
   "notesImport_unavailable": "Temporarily unavailable. Please try again later.",
   "notesImport_unavailableBanner": "Scribe AI is temporarily unavailable. Please check again later.",
   "notesImport_unavailableBannerDetail": "Scribe AI is temporarily unavailable. Please check again later. {{detail}}",
+  "notesImport_updateRequired": "Update WitnessWork to use Notes Import.",
+  "notesImport_updateRequiredBanner": "Your app version {{current}} is below the minimum {{min}} required for Notes Import. Update WitnessWork to continue.",
   "notesImport_listEmptyTitle": "No imports yet",
   "notesImport_listEmptyBody": "Paste field-ministry notes and Scribe AI will turn them into Contacts, Visits, and Time Entries for you to review.",
   "notesImport_newImport": "New Scribe AI import",


### PR DESCRIPTION
Reads the new `minAppVersion` from `GET /notes-import/status` (leviFrosty/ww-api#5) and, when this build's `app.config.ts` version is below it, treats Notes Import as unavailable (`version_below_min`): the composer input is disabled, the banner reads "Your app version X is below the minimum Y required for Notes Import. Update WitnessWork to continue." with an **Update** button to the App Store, and the Settings row is disabled with an update hint. Fail-open when no floor / unparseable / probe fails. Runbook for bumping the floor in `docs/notes-import-min-version.md`.

HITL: after merging + deploying ww-api#5, set `notes-import:min-version` in the dev KV above the current dev build and confirm the composer disables and the Update button opens the App Store.