### PR TITLE
fix(map): patch carousel scrollTo mirror bug behind wrong-person pin taps

### DIFF
--- a/patches/react-native-reanimated-carousel@4.0.3.patch
+++ b/patches/react-native-reanimated-carousel@4.0.3.patch
@@ -1,0 +1,124 @@
+diff --git a/src/hooks/useCarouselController.tsx b/src/hooks/useCarouselController.tsx
+index 38af010de891f17129be6e85f7c0abaedf28e21b..1ad03cea670f628d4d9d9b9fa73c0b6eeee1db6f 100644
+--- a/src/hooks/useCarouselController.tsx
++++ b/src/hooks/useCarouselController.tsx
+@@ -9,12 +9,12 @@ import type {
+   TCarouselProps,
+   WithTimingAnimation,
+ } from "../types";
++import { computeScrollToTargetOffset } from "../utils/compute-scroll-to-target-offset";
+ import {
+   computedRealIndexWithAutoFillData,
+   convertToSharedIndex,
+ } from "../utils/computed-with-auto-fill-data";
+ import { dealWithAnimation } from "../utils/deal-with-animation";
+-import { handlerOffsetDirection } from "../utils/handleroffset-direction";
+ import { round } from "../utils/log";
+ 
+ interface IOpts {
+@@ -267,25 +267,15 @@ export function useCarouselController(options: IOpts): ICarouselController {
+       if (!canSliding()) return;
+ 
+       onScrollStart?.();
+-      // direction -> 1 | -1
+-      const direction = handlerOffsetDirection(handlerOffset, fixedDirection);
+ 
+-      // target offset
+-      const offset = i * size * direction;
+-      // page width size * page count
+-      const totalSize = dataInfo.length * size;
+-
+-      let isCloseToNextLoop = false;
+-
+-      if (loop) {
+-        isCloseToNextLoop = Math.abs(handlerOffset.value % totalSize) / totalSize >= 0.5;
+-      }
+-
+-      const finalOffset =
+-        (Math.floor(Math.abs(handlerOffset.value / totalSize)) + (isCloseToNextLoop ? 1 : 0)) *
+-          totalSize *
+-          direction +
+-        offset;
++      const finalOffset = computeScrollToTargetOffset({
++        index: i,
++        size,
++        handlerOffsetValue: handlerOffset.value,
++        dataLength: dataInfo.length,
++        loop,
++        fixedDirection,
++      });
+ 
+       if (animated) {
+         index.value = i;
+diff --git a/src/utils/compute-scroll-to-target-offset.ts b/src/utils/compute-scroll-to-target-offset.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..2370bfc23f06d3b4cc770c8fef14271b24284511
+--- /dev/null
++++ b/src/utils/compute-scroll-to-target-offset.ts
+@@ -0,0 +1,66 @@
++// Deliberately dependency-free: the consuming app's regression test imports
++// this file directly, and pulling in ../types would drag the package's raw
++// TS (written against an older reanimated) into the app's typecheck.
++type TFixedDirection = "positive" | "negative";
++
++/**
++ * Computes the handlerOffset a `scrollTo({ index })` call should settle at.
++ *
++ * The legacy formula (`index * size * direction`, plus whole-loop cycles)
++ * breaks in loop mode whenever the current handlerOffset is positive — i.e.
++ * after the user swiped backwards past the start. `+index * size` is the
++ * mirrored frame, so the carousel visually lands on `dataLength - index`
++ * while getCurrentIndex/onSnapToItem report that same mirrored value.
++ *
++ * In loop mode (without a fixedDirection override) we instead anchor on the
++ * page the carousel is actually resting on and travel the shortest modular
++ * distance to the requested index, which is frame-correct for either offset
++ * sign. Non-loop carousels and fixedDirection users keep the legacy formula:
++ * non-loop offsets never go positive, and fixedDirection intentionally pins
++ * the frame.
++ */
++export function computeScrollToTargetOffset(params: {
++  index: number;
++  size: number;
++  handlerOffsetValue: number;
++  dataLength: number;
++  loop: boolean;
++  fixedDirection?: TFixedDirection;
++}): number {
++  "worklet";
++
++  const { index: i, size, handlerOffsetValue, dataLength, loop, fixedDirection } = params;
++
++  const totalSize = dataLength * size;
++
++  if (loop && !fixedDirection) {
++    const currentPage = -Math.round(handlerOffsetValue / size);
++    const currentIndex = ((currentPage % dataLength) + dataLength) % dataLength;
++    let delta = (i - currentIndex) % dataLength;
++    if (delta > dataLength / 2) delta -= dataLength;
++    else if (delta < -dataLength / 2) delta += dataLength;
++    return -(currentPage + delta) * size;
++  }
++
++  // Legacy behaviour, unchanged.
++  const direction =
++    fixedDirection === "negative"
++      ? -1
++      : fixedDirection === "positive"
++        ? 1
++        : handlerOffsetValue === 0
++          ? -1
++          : (Math.sign(handlerOffsetValue) as -1 | 1);
++
++  const offset = i * size * direction;
++
++  let isCloseToNextLoop = false;
++  if (loop) isCloseToNextLoop = Math.abs(handlerOffsetValue % totalSize) / totalSize >= 0.5;
++
++  return (
++    (Math.floor(Math.abs(handlerOffsetValue / totalSize)) + (isCloseToNextLoop ? 1 : 0)) *
++      totalSize *
++      direction +
++    offset
++  );
++}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ overrides:
 
 patchedDependencies:
   expo-alternate-app-icons: e03bd1668a2ea072fbd4845ebec286ec5021f27907fdd8ac64801e8350b5438c
+  react-native-reanimated-carousel@4.0.3: 4fbbd5207631d13e6dc864fa634303e2d5b4fc73adacd62ce79d2ad6fb96f828
 
 importers:
   .:
@@ -271,7 +272,7 @@ importers:
         version: 4.5.1(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react-native-reanimated-carousel:
         specifier: ^4.0.3
-        version: 4.0.3(8d85665559d7c3f0a3d6e2a52c2d3570)
+        version: 4.0.3(patch_hash=4fbbd5207631d13e6dc864fa634303e2d5b4fc73adacd62ce79d2ad6fb96f828)(8d85665559d7c3f0a3d6e2a52c2d3570)
       react-native-safe-area-context:
         specifier: 5.7.0
         version: 5.7.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -19572,7 +19573,7 @@ snapshots:
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  react-native-reanimated-carousel@4.0.3(8d85665559d7c3f0a3d6e2a52c2d3570):
+  react-native-reanimated-carousel@4.0.3(patch_hash=4fbbd5207631d13e6dc864fa634303e2d5b4fc73adacd62ce79d2ad6fb96f828)(8d85665559d7c3f0a3d6e2a52c2d3570):
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,4 +36,5 @@ overrides:
   'ws@8': '^8.21.3'
 patchedDependencies:
   expo-alternate-app-icons: patches/expo-alternate-app-icons.patch
+  react-native-reanimated-carousel@4.0.3: patches/react-native-reanimated-carousel@4.0.3.patch
 enableGlobalVirtualStore: true

--- a/src/__tests__/mapCarouselScrollToDirection.test.ts
+++ b/src/__tests__/mapCarouselScrollToDirection.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeScrollToTargetOffset } from 'react-native-reanimated-carousel/src/utils/compute-scroll-to-target-offset'
+import { round } from 'react-native-reanimated-carousel/src/utils/log'
+
+/**
+ * Regression test for the map screen's "tap a pin, the carousel shows the wrong
+ * person" bug (react-native-reanimated-carousel@4.0.3).
+ *
+ * MapScreen's pin tap calls carouselRef.scrollTo({ index }) and presents the
+ * centered card as "the tapped person". Unpatched, the library's `to()`
+ * (src/hooks/useCarouselController.tsx) targets `index * size * direction`
+ * where direction is the sign of the current offset — so once handlerOffset is
+ * positive (the user swiped backwards past the start in loop mode) every
+ * scrollTo visually centers item `dataLength - index`, the wrong person, while
+ * onSnapToItem and getCurrentIndex report that same mirrored value and the
+ * app's id-based reconciliation cannot detect the mismatch.
+ *
+ * `patches/react-native-reanimated-carousel@4.0.3.patch` fixes this by
+ * extracting the target-offset math into computeScrollToTargetOffset (which
+ * this test imports — the exact code Metro bundles, since the package's
+ * `react-native` entry points at src/) and making the loop-mode path anchor on
+ * the resting page instead of mirroring. The surrounding pipeline below is
+ * simulated with formulas copied verbatim from the (unpatched) library:
+ *
+ * - Active-index reaction — src/hooks/useCarouselController.tsx:92-116
+ * - `offsetX` normalization — src/components/CarouselLayout.tsx:58-65
+ * - Per-item translate sawtooth — src/hooks/useOffsetX.ts:27-76
+ *
+ * If a future package upgrade drops the patch, the import above fails and this
+ * suite goes red — re-verify the upstream scrollTo math before removing.
+ */
+
+const SIZE = 390 // card width; any positive size behaves identically
+
+// interpolate(..., Extrapolation.CLAMP) — piecewise linear, clamped ends
+function interpolateClamp(
+  x: number,
+  inputRange: number[],
+  outputRange: number[]
+): number {
+  if (x <= inputRange[0]) return outputRange[0]
+  if (x >= inputRange[inputRange.length - 1])
+    return outputRange[outputRange.length - 1]
+  for (let k = 0; k < inputRange.length - 1; k++) {
+    const [a, b] = [inputRange[k], inputRange[k + 1]]
+    if (x >= a && x <= b) {
+      const t = b === a ? 0 : (x - a) / (b - a)
+      return outputRange[k] + t * (outputRange[k + 1] - outputRange[k])
+    }
+  }
+  return outputRange[outputRange.length - 1]
+}
+
+// useCarouselController `to()` — computes the new handlerOffset for a
+// scrollTo({ index: i }) call, via the real (patched) library util.
+function scrollToIndex(params: {
+  i: number
+  handlerOffset: number
+  dataLength: number
+  loop: boolean
+}): number {
+  const { i, handlerOffset, dataLength, loop } = params
+  return computeScrollToTargetOffset({
+    index: i,
+    size: SIZE,
+    handlerOffsetValue: handlerOffset,
+    dataLength,
+    loop,
+  })
+}
+
+// useCarouselController's useAnimatedReaction — the index reported through
+// getCurrentIndex()/onSnapToItem once the offset settles.
+function reportedIndex(handlerOffset: number, dataLength: number): number {
+  const toInt = round(handlerOffset / SIZE) % dataLength
+  const isPositive = handlerOffset <= 0
+  return isPositive
+    ? Math.abs(toInt)
+    : Math.abs(toInt > 0 ? dataLength - toInt : 0)
+}
+
+// CarouselLayout offsetX + useOffsetX — which item the user actually sees
+// centered in the viewport (translate x === 0).
+function visuallyCenteredIndex(
+  handlerOffset: number,
+  dataLength: number
+): number | undefined {
+  const totalSize = SIZE * dataLength
+  const offsetX = handlerOffset % totalSize
+
+  const VALID_LENGTH = dataLength - 1
+  const viewCount = Math.round((dataLength - 1) / 2)
+  const positiveCount = viewCount
+  const MAX = positiveCount * SIZE
+  const MIN = -(VALID_LENGTH - positiveCount) * SIZE
+  const HALF = 0.5 * SIZE
+
+  let centered: number | undefined
+  for (let index = 0; index < dataLength; index++) {
+    let startPos = SIZE * index
+    if (index > positiveCount) startPos = (index - dataLength) * SIZE
+
+    const inputRange = [
+      -totalSize,
+      MIN - HALF - startPos - Number.MIN_VALUE,
+      MIN - HALF - startPos,
+      0,
+      MAX + HALF - startPos,
+      MAX + HALF - startPos + Number.MIN_VALUE,
+      totalSize,
+    ]
+    const outputRange = [
+      startPos,
+      MAX + HALF - Number.MIN_VALUE,
+      MIN - HALF,
+      startPos,
+      MAX + HALF,
+      MIN - HALF + Number.MIN_VALUE,
+      startPos,
+    ]
+
+    const x = interpolateClamp(offsetX, inputRange, outputRange)
+    if (Math.abs(x) < 1e-6) centered = index
+  }
+  return centered
+}
+
+// One simulated pin tap on the map screen: scrollTo({ index }) then read what
+// the user sees and what the carousel reports back to the app.
+function tapPin(params: {
+  tappedIndex: number
+  handlerOffset: number
+  dataLength: number
+}) {
+  const { tappedIndex, handlerOffset, dataLength } = params
+  const settled = scrollToIndex({
+    i: tappedIndex,
+    handlerOffset,
+    dataLength,
+    loop: true,
+  })
+  return {
+    settledOffset: settled,
+    visible: visuallyCenteredIndex(settled, dataLength),
+    reported: reportedIndex(settled, dataLength),
+  }
+}
+
+const MARKER_COUNT = 57 // the reporting user's backup: 57 contacts with pins
+
+describe('reanimated-carousel scrollTo({index}) direction bug (map pin taps)', () => {
+  it('control: from a fresh carousel (offset 0), every pin tap centers the tapped contact', () => {
+    for (let i = 1; i < MARKER_COUNT; i++) {
+      const { visible, reported } = tapPin({
+        tappedIndex: i,
+        handlerOffset: 0,
+        dataLength: MARKER_COUNT,
+      })
+      expect(visible, `tapped ${i}`).toBe(i)
+      expect(reported, `tapped ${i}`).toBe(i)
+    }
+  })
+
+  it('control: after forward swipes (negative offset), pin taps center the tapped contact', () => {
+    for (let i = 0; i < MARKER_COUNT; i++) {
+      if (i === 3) continue // scrollTo is a no-op when already on the index
+      const { visible } = tapPin({
+        tappedIndex: i,
+        handlerOffset: -3 * SIZE, // user swiped forward to card 3
+        dataLength: MARKER_COUNT,
+      })
+      expect(visible, `tapped ${i}`).toBe(i)
+    }
+  })
+
+  it('after one backward swipe (positive offset), pin taps still center the tapped contact', () => {
+    // User swipes backwards once from the first card: loop wraps to the last
+    // card and handlerOffset settles at +SIZE.
+    const handlerOffset = +SIZE
+
+    const failures: Array<{
+      tapped: number
+      visible?: number
+      reported: number
+    }> = []
+    for (let i = 0; i < MARKER_COUNT; i++) {
+      const { visible, reported } = tapPin({
+        tappedIndex: i,
+        handlerOffset,
+        dataLength: MARKER_COUNT,
+      })
+      if (visible !== i || reported !== i)
+        failures.push({ tapped: i, visible, reported })
+    }
+
+    // Red on the unpatched library: every tap lands on
+    // (dataLength - tapped) % dataLength — and onSnapToItem/getCurrentIndex
+    // report that same mirrored value, so MapScreen's id-based reconciliation
+    // could never catch it. Green with the patch.
+    expect(failures).toEqual([])
+  })
+
+  it('holds for every marker count, target, and resting offset', () => {
+    for (let n = 3; n <= 60; n++) {
+      for (const pages of [-2, -1, 1, 2, n - 1, -(n - 1)]) {
+        for (let i = 0; i < n; i++) {
+          const { visible, reported } = tapPin({
+            tappedIndex: i,
+            handlerOffset: pages * SIZE,
+            dataLength: n,
+          })
+          const at = `n=${n} offset=${pages} tapped=${i}`
+          expect(visible, at).toBe(i)
+          expect(reported, at).toBe(i)
+        }
+      }
+    }
+  })
+})

--- a/src/features/map/screens/MapScreen.tsx
+++ b/src/features/map/screens/MapScreen.tsx
@@ -893,6 +893,16 @@ const FullMapView = ({
         </View>
       ) : (
         <Carousel
+          // TODO: react-native-reanimated-carousel@4.0.3 is patched
+          // (patches/react-native-reanimated-carousel@4.0.3.patch): unpatched,
+          // scrollTo({ index }) mirrors the target after a backward swipe in
+          // loop mode, centering the wrong contact's card on pin taps.
+          // Upstream fixed this in the v5 rewrite — upgrading to v5 removes
+          // the patch, but changes this component's API (layout replaces
+          // mode/modeConfig; windowSize and scrollAnimationDuration are
+          // dropped). Guarded by mapCarouselScrollToDirection.test.ts, which
+          // goes red if an upgrade drops the patch.
+          //
           // Remount when crossing the 1↔many boundary. `loop` cannot be
           // toggled mid-life on react-native-reanimated-carousel — when a
           // search narrows results to a single match the carousel keeps its


### PR DESCRIPTION
Patches `react-native-reanimated-carousel@4.0.3` (pnpm patch) so `scrollTo({ index })` anchors on the carousel's resting page and travels the shortest modular distance in loop mode. Unpatched, one backward swipe on the map's card carousel flips its internal offset positive and every subsequent pin tap centers the mirrored card (`dataLength − index`) — the wrong contact — while `getCurrentIndex`/`onSnapToItem` report that same mirrored value, invisible to the app's id-based reconciliation. Adds a regression suite that imports the patched util (the same `src/` files Metro bundles) and sweeps marker counts, resting offsets, and targets, plus a TODO at the map's `<Carousel>` pointing at the patch.

**HITL check before release:** on device, open Map → swipe the card carousel backwards (right) once → tap a distant pin; the centered card must match the tapped pin.

---

## Follow-up: upgrade to carousel v5 and delete the patch

Upstream fixed this bug class in the v5 rewrite (`scrollTo` anchors on `currentVisualPage()` + `getShortestLoopTargetPage`). Prompt for whoever/whatever agent takes it:

> Upgrade `react-native-reanimated-carousel` from patched 4.0.3 to ^5.1.1 in WitnessWork and remove `patches/react-native-reanimated-carousel@4.0.3.patch` (and its `pnpm-workspace.yaml` entry). The only consumer is `src/features/map/screens/MapScreen.tsx`. Peer deps are already satisfied (RN 0.86, reanimated 4.5, worklets 0.10, gesture-handler 2.32). API migration to verify against v5's `public-types.ts`, not the old docs:
> - `mode='parallax'` + `modeConfig={{parallaxScrollingScale}}` → `layout={{ type: 'parallax', scale/adjacentScale/offset }}`; match the current visual by eye on device.
> - `windowSize` and `scrollAnimationDuration` no longer exist — confirm what v5 does for item mounting (windowing was the map screen's first-paint fix, commit 1bb01eed) and animation duration (was 125ms), and find equivalents or measure that defaults are acceptable.
> - `renderItem` now receives `relativeProgress` (SharedValue) instead of `animationValue`; MapCarouselCard doesn't use it, so likely just a type change.
> - Ref semantics changed: `scrollTo` defaults to `animated: true`, validates index bounds, and `getCurrentIndex` returns the settled index; snap callback may be `onMovementEnd`-based — re-check `onSnapToItem`, `onScrollStart`, and `onFinished` wiring in `handlePinPress`, `handleCarouselSnap`, and the reconcile effect, including the `programmaticScrollRef`/`suppressCarouselDismissUntilRef` keyboard-dismiss suppression and the 1↔many remount key workaround (v5 may allow toggling `loop`).
> - Update `src/__tests__/mapCarouselScrollToDirection.test.ts`: the patched-util import will fail by design. Re-point the simulation at v5's real pure helpers (`getShortestLoopTargetPage`, `positiveModulo`, offset math) so the mirror regression stays covered, or port the sweep to v5's equivalents.
> - On-device regression: pin tap → correct card (especially after one backward swipe), swipe feel/parallax, search narrowing to 1 result and back, keyboard staying focused while typing filters, carousel↔pin reconciliation after dismissing a contact.