### PR TITLE
fix: restore filled book icon for current-month Bible studies

### DIFF
--- a/src/features/contacts/components/ContactRow.tsx
+++ b/src/features/contacts/components/ContactRow.tsx
@@ -241,6 +241,7 @@ const ContactRow = ({
                       ? theme.colors.text
                       : theme.colors.textAlt,
                   }}
+                  fill={isActiveBibleStudy ? theme.colors.text : 'none'}
                   icon={BookOpenIcon}
                 />
               )}


### PR DESCRIPTION
The contacts-list book icon now renders filled when the contact was studied with in the current month, and stays outline-gray for past studies — restoring the contrast lost in the Lucide icon migration.

Fixes #437