### PR TITLE
feat: add deferred home announcements with Markdown details

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,6 @@ EXPO_PUBLIC_SILENT=false
 # In .env.production, leave BOTH blank so the app uses the production proxy.
 EXPO_PUBLIC_NOTES_IMPORT_BASE_URL=
 EXPO_PUBLIC_NOTES_IMPORT_DEV_BYPASS=
+# Optional announcement Worker override. Defaults to the Notes Import base URL,
+# then production. Cached content is isolated by URL; no credentials are sent.
+EXPO_PUBLIC_ANNOUNCEMENTS_BASE_URL=

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,0 +1,83 @@
+# Runtime announcements
+
+WitnessWork displays one informational announcement above the Home profile card.
+Tapping it opens a dismissible sheet with native Markdown, uploaded images,
+HTTPS/email links, and optionally the existing Levi signature art and name.
+The announcement's `dismissible` flag controls the banner's dismiss button; the
+detail sheet can always be closed. No announcement blocks app features.
+
+## Authoring and publishing
+
+The sibling `ww-api` repository owns the local rich-text editor, publication-time
+Codex/Claude translation, private R2 draft, immutable releases/images, and current
+JSON feed. Start `pnpm admin:announcements` there (or append `--dev`) after setting
+its environment-specific admin credentials. See that repository's
+`docs/announcements-admin.md` and `docs/announcements-api.md` for the workflow,
+Cloudflare setup, API contract, and cache behavior. No publishing token is
+bundled into the app. Existing human-approved app locale files are untouched;
+the separately published announcement content carries its own translations.
+
+The feed is `GET /announcements/current.json`, containing `schemaVersion: 1` and
+either one announcement or `announcement: null`. All 18 supported translations
+fit in one response; the current app locale selects copy, falling back to
+English. Uploaded relative image paths resolve against the same Worker origin.
+An optional `EXPO_PUBLIC_ANNOUNCEMENTS_BASE_URL` overrides that origin; otherwise
+it follows the Notes Import environment URL, then the production Worker.
+
+Use a stable `id` when correcting an existing item: dismissal persists across
+revisions. Create a new ID when everyone should see a new message. Dismissals
+and the cache remain on this device, separate from iCloud Sync and backups of
+field-service records. The last 100 dismissed IDs are retained.
+
+## Launch behavior
+
+Home takes a snapshot of already-cached content before its first layout. The
+network never inserts a banner into the current launch, including when Home is
+opened later from another tab or a deep link. A newly downloaded announcement
+appears on the **next app launch**. This deliberate delay avoids slow-network
+layout shifts without leaving an empty banner placeholder in the UI.
+
+After navigation is ready, `deferUntilNotBlocking` waits for registered startup
+work: RevenueCat identification (including cached fallback), account/iCloud
+reconciliation, Notes Import availability probes, and App Attest preparation.
+It waits for a quiet second, two animation frames, then React Native's
+`requestIdleCallback` while the app is foregrounded. New startup work pauses
+scheduling. If startup never settles within 30 seconds, optional work is
+skipped for this launch. iOS inactivity before fetching pauses scheduling;
+backgrounding during a fetch aborts it. There is no polling or retry on resume.
+
+There is at most one request per JavaScript launch, and no request when a
+successful cache check is less than six hours old. Conditional requests use
+ETags. Requests abort after five seconds. Offline errors, invalid responses,
+storage failures, and timeouts are silent. The existing cache remains usable
+for at most 24 hours after its last successful check. Start/expiration dates
+are checked locally, and stale/expired content is removed while the app stays
+open. Only user-requested detail sheets load remote images.
+
+The Worker caches the feed for an hour. Combined with device caching and the
+next-launch presentation rule, publication and withdrawal are intentionally
+eventual. Use Notes Import's existing availability gate for disabling that
+feature; announcements only explain an event and are not an emergency control.
+
+## Native build and validation
+
+`react-native-enriched-markdown` 1.0.2 supports the app's React Native 0.86
+Fabric renderer. Math and syntax-highlighting native assets are disabled; plain
+informational Markdown does not need them. The sheet respects app text sizing,
+theme colors, and native accessibility scaling. URL opening permits only HTTPS
+and email; link previews and interactive task-list controls are disabled.
+
+This dependency needs a **new iOS binary**. Do not distribute this change as an
+OTA update to an existing binary with the same app-version runtime. Apply the
+normal release version bump when preparing the binary; this feature PR does
+not cut an App Store release. It cannot run in Expo Go.
+
+The client tests exercise next-launch visibility, dismissal across revisions,
+cache expiration, ETag revalidation, withdrawal, schema errors, offline/timeout
+behavior, environment isolation, Chinese-script fallback, and safe links. The
+scheduler tests exercise asynchronous startup barriers, new work between
+frames, foregrounding, cancellation, and hung startup.
+
+Sources: [Expo rich-text guidance](https://docs.expo.dev/guides/editing-richtext/),
+[React Native idle scheduling](https://reactnative.dev/docs/global-requestIdleCallback),
+[Enriched Markdown compatibility and configuration](https://github.com/software-mansion/enriched-markdown/blob/main/packages/react-native-enriched-markdown/README.md).

--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
     "i18n-js": "^4.5.3",
     "jest-expo": "~57.0.1",
     "lodash": "^4.18.1",
-    "lucide-react-native": "^1.23.0",
     "lottie-react-native": "7.3.8",
+    "lucide-react-native": "^1.23.0",
     "madge": "^8.0.0",
     "moment": "^2.30.1",
     "prop-types": "^15.8.1",
@@ -99,6 +99,7 @@
     "react-dom": "19.2.3",
     "react-native": "0.86.0",
     "react-native-calendars": "^1.1314.0",
+    "react-native-enriched-markdown": "1.0.2",
     "react-native-gesture-handler": "~2.32.0",
     "react-native-international-phone-number": "^0.8.7",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
@@ -147,6 +148,10 @@
     "vitest": "^4.1.9"
   },
   "private": true,
+  "enriched-markdown": {
+    "enableCodeHighlight": false,
+    "enableMath": false
+  },
   "expo": {
     "install": {
       "exclude": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
       react-native-calendars:
         specifier: ^1.1314.0
         version: 1.1314.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+      react-native-enriched-markdown:
+        specifier: 1.0.2
+        version: 1.0.2(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react-native-gesture-handler:
         specifier: ~2.32.0
         version: 2.32.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -9980,6 +9983,19 @@ packages:
       react-native-gesture-handler: '>= 2.0.0'
       react-native-reanimated: '>= 2.0.0'
 
+  react-native-enriched-markdown@1.0.2:
+    resolution:
+      {
+        integrity: sha512-zvVM4W1VMV/cYAKUTYoVheadOGHLbny2kALFn0vi5av/WFa0JSYboeeq/vPRqS5dc8qvUTjXwVlrkhrcuinNQA==,
+      }
+    peerDependencies:
+      katex: '>=0.16.0'
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      katex:
+        optional: true
+
   react-native-gesture-handler@2.32.0:
     resolution:
       {
@@ -19516,6 +19532,11 @@ snapshots:
       react-native-gesture-handler: 2.32.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react-native-reanimated: 4.5.1(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       use-latest-callback: 0.2.4(react@19.2.3)
+
+  react-native-enriched-markdown@1.0.2(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
 
   react-native-gesture-handler@2.32.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ allowBuilds:
   '@shopify/react-native-skia': true
   esbuild: true
   protobufjs: false
+  react-native-enriched-markdown: true
   unrs-resolver: true
 onlyBuiltDependencies:
   - '@sentry/cli'

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -68,6 +68,8 @@ import { isOfflineError } from '@/lib/offlineError'
 import { isLocationTemporarilyUnavailableError } from '@/lib/locationError'
 import { useNotesImportManager } from '@/features/notes-import/hooks/useNotesImportManager'
 import { prepareNotesImportAppAttestRecovery } from '@/features/notes-import/lib/notesImportAppAttestRuntime'
+import { beginStartupWork } from '@/lib/deferUntilNotBlocking'
+import AnnouncementStartup from '@/app/components/AnnouncementStartup'
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -134,10 +136,13 @@ function SupporterStoreSync() {
  */
 function NotesImportAttestPreparation() {
   useEffect(() => {
-    void prepareNotesImportAppAttestRecovery().catch(() => {
-      // Best effort. The normal Notes Import path retries through the same module
-      // and presents its localized error if enrollment still cannot complete.
-    })
+    const finishStartup = beginStartupWork()
+    void prepareNotesImportAppAttestRecovery()
+      .catch(() => {
+        // Best effort. The normal Notes Import path retries through the same module
+        // and presents its localized error if enrollment still cannot complete.
+      })
+      .finally(finishStartup)
   }, [])
   return null
 }
@@ -306,6 +311,7 @@ export default function App() {
     Kalam_700Bold,
   })
   const [hasMigrated, setHasMigrated] = useState(hasMigratedFromAsyncStorage())
+  const [navigationReady, setNavigationReady] = useState(false)
 
   // Dev-only: bumping this key remounts the whole navigation tree (every
   // screen back to initial state) without a Metro bundle reload, so an
@@ -615,6 +621,7 @@ export default function App() {
                   key={devRemountKey}
                   ref={navigationRef}
                   linking={linking}
+                  onReady={() => setNavigationReady(true)}
                 >
                   {/*
                    * ToastProvider must wrap TamaguiProvider — TamaguiProvider
@@ -643,6 +650,7 @@ export default function App() {
                         <AnimationViewProvider>
                           <DeepLinkListeners />
                           <RootStackComponent />
+                          {navigationReady && <AnnouncementStartup />}
                         </AnimationViewProvider>
                       </ConfettiProvider>
                     </TamaguiProvider>

--- a/src/app/components/AnnouncementStartup.tsx
+++ b/src/app/components/AnnouncementStartup.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+import { AppState } from 'react-native'
+import { deferUntilNotBlocking } from '@/lib/deferUntilNotBlocking'
+import { announcementClient } from '@/features/announcements/lib/announcementRuntime'
+
+/** Mounted only after navigation is ready; never delays the app's own UI. */
+export default function AnnouncementStartup() {
+  useEffect(() => {
+    const controller = new AbortController()
+    let started = false
+    const cancel = deferUntilNotBlocking(
+      () => {
+        started = true
+        void announcementClient.checkForUpdates(controller.signal)
+      },
+      { signal: controller.signal }
+    )
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (started && state !== 'active') controller.abort()
+    })
+    return () => {
+      controller.abort()
+      cancel()
+      subscription.remove()
+    }
+  }, [])
+  return null
+}

--- a/src/constants/apis.ts
+++ b/src/constants/apis.ts
@@ -3,8 +3,11 @@ const BASE_URL = 'https://ww-proxy.leviwilkerson.com'
 // Notes Import may target a separate (dev/staging) worker so the App Attest
 // dev-bypass path never touches production. Falls back to the prod proxy.
 const NOTES_BASE_URL = process.env.EXPO_PUBLIC_NOTES_IMPORT_BASE_URL || BASE_URL
+const ANNOUNCEMENTS_BASE_URL =
+  process.env.EXPO_PUBLIC_ANNOUNCEMENTS_BASE_URL || NOTES_BASE_URL
 
 export default {
+  announcements: `${ANNOUNCEMENTS_BASE_URL.replace(/\/$/, '')}/announcements/current.json`,
   geocode: `${BASE_URL}/geocode`,
   autocomplete: `${BASE_URL}/autocomplete`,
   // Unauthenticated worker health probe ({ status, versionId, deployedAt }) —

--- a/src/features/announcements/components/AnnouncementBanner.tsx
+++ b/src/features/announcements/components/AnnouncementBanner.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react'
+import { AppState, View } from 'react-native'
+import { ChevronRight, Megaphone, X } from 'lucide-react-native'
+import Button from '@/components/ui/Button'
+import Card from '@/components/ui/Card'
+import IconButton from '@/components/ui/IconButton'
+import Text from '@/components/ui/MyText'
+import useTheme from '@/contexts/theme'
+import i18n, { _i18n } from '@/lib/locales'
+import { usePreferences } from '@/stores/preferences'
+import { announcementContent } from '@/features/announcements/lib/announcement'
+import { announcementClient } from '@/features/announcements/lib/announcementRuntime'
+import AnnouncementSheet from '@/features/announcements/components/AnnouncementSheet'
+
+export default function AnnouncementBanner() {
+  const theme = useTheme()
+  const locale = usePreferences((state) => state.locale)
+  const [announcement, setAnnouncement] = useState(
+    announcementClient.getLaunchAnnouncement
+  )
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (!announcement) return
+    // Removal is allowed when cached information ages out. A foreground event
+    // never introduces a new item or makes another network request.
+    const check = () => {
+      if (!announcementClient.getLaunchAnnouncement()) {
+        setOpen(false)
+        setAnnouncement(null)
+      }
+    }
+    const timer = setInterval(check, 60_000)
+    const subscription = AppState.addEventListener('change', check)
+    return () => {
+      clearInterval(timer)
+      subscription.remove()
+    }
+  }, [announcement])
+
+  if (!announcement) return null
+  const content = announcementContent(announcement, locale ?? _i18n.locale)
+
+  return (
+    <>
+      <Card
+        style={{ paddingVertical: 0, paddingHorizontal: 12, gap: 8 }}
+        flexDirection='row'
+      >
+        <Button
+          noTransform
+          accessibilityRole='button'
+          accessibilityLabel={content.bannerText}
+          onPress={() => setOpen(true)}
+          hitSlop={0}
+          style={{
+            flex: 1,
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 10,
+            minHeight: 52,
+            paddingVertical: 12,
+          }}
+        >
+          <Megaphone size={18} color={theme.colors.accent} accessible={false} />
+          <Text
+            style={{
+              flex: 1,
+              fontSize: theme.fontSize('sm'),
+              fontFamily: theme.fonts.semiBold,
+            }}
+          >
+            {content.bannerText}
+          </Text>
+          <ChevronRight
+            size={16}
+            color={theme.colors.textAlt}
+            accessible={false}
+          />
+        </Button>
+        {announcement.dismissible && (
+          <View style={{ justifyContent: 'center' }}>
+            <IconButton
+              noTransform
+              icon={X}
+              size={18}
+              hitSlop={0}
+              style={{
+                minWidth: 44,
+                minHeight: 44,
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+              accessibilityLabel={i18n.t('dismiss')}
+              onPress={() => {
+                announcementClient.dismiss(announcement.id)
+                setOpen(false)
+                setAnnouncement(null)
+              }}
+            />
+          </View>
+        )}
+      </Card>
+      {open && (
+        <AnnouncementSheet
+          announcement={announcement}
+          content={content}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  )
+}

--- a/src/features/announcements/components/AnnouncementSheet.tsx
+++ b/src/features/announcements/components/AnnouncementSheet.tsx
@@ -1,0 +1,193 @@
+import { Linking, View } from 'react-native'
+import { Sheet } from 'tamagui'
+import { X } from 'lucide-react-native'
+import { Image } from 'expo-image'
+import { GlassView } from 'expo-glass-effect'
+import { EnrichedMarkdownText } from 'react-native-enriched-markdown'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import IconButton from '@/components/ui/IconButton'
+import Text from '@/components/ui/MyText'
+import useTheme from '@/contexts/theme'
+import useGlassColorScheme from '@/hooks/useGlassColorScheme'
+import i18n from '@/lib/locales'
+import apis from '@/constants/apis'
+import { usePreferences } from '@/stores/preferences'
+import {
+  safeAnnouncementLink,
+  resolveAnnouncementImages,
+  type Announcement,
+} from '@/features/announcements/lib/announcement'
+
+export default function AnnouncementSheet({
+  announcement,
+  content,
+  onClose,
+}: {
+  announcement: Announcement
+  content: Announcement['locales'][string]
+  onClose: () => void
+}) {
+  const theme = useTheme()
+  const glassColorScheme = useGlassColorScheme()
+  const insets = useSafeAreaInsets()
+  const offset = usePreferences((state) => state.fontSizeOffset)
+  const body = {
+    fontFamily: theme.fonts.regular,
+    fontSize: 16 + offset,
+    color: theme.colors.text,
+    lineHeight: 25 + offset,
+  }
+  // Published images are immutable paths within the same announcement service.
+  // Resolve both inline and reference-style Markdown image destinations.
+  const markdown = resolveAnnouncementImages(
+    content.markdown,
+    apis.announcements
+  )
+
+  return (
+    <Sheet
+      open
+      modal
+      onOpenChange={(value: boolean) => {
+        if (!value) onClose()
+      }}
+      dismissOnSnapToBottom
+      transition='quick'
+      snapPoints={[85]}
+    >
+      <Sheet.Overlay />
+      <Sheet.Handle />
+      <Sheet.Frame backgroundColor={theme.colors.background}>
+        <GlassView
+          glassEffectStyle='regular'
+          colorScheme={glassColorScheme}
+          style={{ flex: 1 }}
+        >
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 16,
+              padding: 20,
+            }}
+          >
+            <Text
+              accessibilityRole='header'
+              style={{
+                flex: 1,
+                fontSize: theme.fontSize('2xl'),
+                fontFamily: theme.fonts.bold,
+              }}
+            >
+              {content.title}
+            </Text>
+            <IconButton
+              noTransform
+              icon={X}
+              size={20}
+              accessibilityLabel={i18n.t('close')}
+              onPress={onClose}
+              style={{
+                minWidth: 44,
+                minHeight: 44,
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            />
+          </View>
+          <Sheet.ScrollView
+            contentContainerStyle={{
+              paddingHorizontal: 20,
+              paddingBottom: insets.bottom + 30,
+            }}
+          >
+            <EnrichedMarkdownText
+              markdown={markdown}
+              flavor='github'
+              md4cFlags={{ latexMath: false }}
+              enableLinkPreview={false}
+              enableTaskListItemToggle={false}
+              selectionMenuConfig={{
+                copyAsMarkdown: { enabled: false },
+                copyImageUrl: { enabled: false },
+              }}
+              onLinkPress={({ url }) => {
+                if (safeAnnouncementLink(url))
+                  void Linking.openURL(url).catch(() => {})
+              }}
+              markdownStyle={{
+                paragraph: body,
+                h1: {
+                  ...body,
+                  fontFamily: theme.fonts.bold,
+                  fontSize: 26 + offset,
+                },
+                h2: {
+                  ...body,
+                  fontFamily: theme.fonts.bold,
+                  fontSize: 23 + offset,
+                },
+                h3: {
+                  ...body,
+                  fontFamily: theme.fonts.semiBold,
+                  fontSize: 20 + offset,
+                },
+                h4: { ...body, fontFamily: theme.fonts.semiBold },
+                h5: { ...body, fontFamily: theme.fonts.semiBold },
+                h6: { ...body, fontFamily: theme.fonts.semiBold },
+                list: {
+                  ...body,
+                  bulletColor: theme.colors.text,
+                  markerColor: theme.colors.text,
+                  itemSpacing: 6,
+                },
+                blockquote: {
+                  ...body,
+                  borderColor: theme.colors.accent,
+                  backgroundColor: theme.colors.card,
+                },
+                link: { color: theme.colors.accent, underline: true },
+                strong: {
+                  fontFamily: theme.fonts.bold,
+                  color: theme.colors.text,
+                },
+                code: {
+                  color: theme.colors.text,
+                  backgroundColor: theme.colors.card,
+                },
+                codeBlock: { ...body, backgroundColor: theme.colors.card },
+                image: { height: 220, resizeMode: 'contain', borderRadius: 12 },
+                thematicBreak: { color: theme.colors.border },
+                table: {
+                  ...body,
+                  headerBackgroundColor: theme.colors.card,
+                  headerTextColor: theme.colors.text,
+                  rowEvenBackgroundColor: theme.colors.background,
+                  rowOddBackgroundColor: theme.colors.card,
+                  borderColor: theme.colors.border,
+                  headerFontFamily: theme.fonts.semiBold,
+                },
+              }}
+            />
+            {announcement.signature && (
+              <View style={{ marginTop: 24, alignItems: 'flex-start', gap: 4 }}>
+                <Image
+                  source={require('@/assets/signature.png')}
+                  style={{ width: 180, height: 64 }}
+                  contentFit='contain'
+                  tintColor={theme.colors.text}
+                  accessible={false}
+                />
+                <Text
+                  style={{ fontFamily: theme.fonts.semiBold, fontSize: 14 }}
+                >
+                  {i18n.t('founderNoteSignOff')}
+                </Text>
+              </View>
+            )}
+          </Sheet.ScrollView>
+        </GlassView>
+      </Sheet.Frame>
+    </Sheet>
+  )
+}

--- a/src/features/announcements/lib/announcement.ts
+++ b/src/features/announcements/lib/announcement.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod'
+
+export const MAX_FEED_BYTES = 256 * 1024
+export const REFRESH_AFTER_MS = 6 * 60 * 60 * 1000
+export const MAX_CACHE_AGE_MS = 24 * 60 * 60 * 1000
+
+const localizedContent = z.object({
+  bannerText: z.string().trim().min(1).max(180),
+  title: z.string().trim().min(1).max(160),
+  markdown: z
+    .string()
+    .min(1)
+    .max(12_000)
+    .refine((value) => Boolean(value.trim())),
+})
+
+const timestamp = z.string().datetime({ offset: true })
+export const announcementSchema = z.object({
+  id: z.string().regex(/^[a-zA-Z0-9_-]{1,80}$/),
+  revision: z.string().min(1).max(100),
+  publishedAt: timestamp,
+  startsAt: timestamp.optional(),
+  expiresAt: timestamp.optional(),
+  dismissible: z.boolean(),
+  signature: z.boolean(),
+  locales: z
+    .record(localizedContent)
+    .refine(
+      (locales) =>
+        Object.keys(locales).length <= 18 && Boolean(locales['en-us'])
+    ),
+})
+
+export const announcementFeedSchema = z.object({
+  schemaVersion: z.literal(1),
+  announcement: announcementSchema.nullable(),
+})
+
+export type Announcement = z.infer<typeof announcementSchema>
+export type AnnouncementFeed = z.infer<typeof announcementFeedSchema>
+
+export function announcementContent(
+  announcement: Announcement,
+  locale: string
+) {
+  const key = locale.toLowerCase().replaceAll('_', '-')
+  // Keep Chinese scripts distinct. Incomplete translations fall back to the
+  // English source, never to a potentially different regional/script variant.
+  const normalized =
+    key === 'zh-tw' ? 'zh-hant-tw' : key === 'zh-cn' ? 'zh-hans-cn' : key
+  return announcement.locales[normalized] ?? announcement.locales['en-us']
+}
+
+export function isAnnouncementActive(announcement: Announcement, now: number) {
+  return (
+    (!announcement.startsAt || Date.parse(announcement.startsAt) <= now) &&
+    (!announcement.expiresAt || now < Date.parse(announcement.expiresAt))
+  )
+}
+
+/** Resolve uploaded inline/reference image destinations, leaving URLs alone. */
+export function resolveAnnouncementImages(markdown: string, endpoint: string) {
+  return markdown.replace(
+    /(\]\([ \t]*<?|^[ \t]{0,3}\[[^\]\r\n]+\]:[ \t]*<?)(\/announcements\/images\/[a-f0-9]{64}\.(?:png|jpg|webp))(?=[\s)>])/gm,
+    (_match, prefix: string, path: string) =>
+      `${prefix}${new URL(path, endpoint).href}`
+  )
+}
+
+/** Native link handling is opt-in: remote copy cannot invoke app/file URLs. */
+export function safeAnnouncementLink(value: string): boolean {
+  if (
+    [...value].some(
+      (character) =>
+        character.charCodeAt(0) <= 32 || character.charCodeAt(0) === 127
+    )
+  )
+    return false
+  try {
+    const url = new URL(value)
+    return (
+      (url.protocol === 'https:' &&
+        Boolean(url.hostname) &&
+        !url.username &&
+        !url.password) ||
+      (url.protocol === 'mailto:' && /^[^@?]+@[^@?]+/.test(url.pathname))
+    )
+  } catch {
+    return false
+  }
+}

--- a/src/features/announcements/lib/announcementClient.test.ts
+++ b/src/features/announcements/lib/announcementClient.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createAnnouncementClient } from '@/features/announcements/lib/announcementClient'
+import {
+  announcementContent,
+  safeAnnouncementLink,
+  resolveAnnouncementImages,
+  type AnnouncementFeed,
+  REFRESH_AFTER_MS,
+  MAX_CACHE_AGE_MS,
+} from '@/features/announcements/lib/announcement'
+
+const endpoint = 'https://example.com/announcements/current.json'
+const now = Date.parse('2026-09-05T12:00:00Z')
+const key = `announcements:v1:${endpoint}`
+const sample: AnnouncementFeed = {
+  schemaVersion: 1,
+  announcement: {
+    id: 'qa-help',
+    revision: 'a5752953-d94e-45f0-8bca-cf7e7f00b1c8',
+    publishedAt: '2026-09-04T12:00:00Z',
+    dismissible: true,
+    signature: true,
+    locales: {
+      'en-us': {
+        bannerText: 'Looking for QA help',
+        title: 'Help test WitnessWork',
+        markdown: '[Email Levi](mailto:levi@example.com)',
+      },
+    },
+  },
+}
+function setup(cached?: { feed?: AnnouncementFeed; age?: number }) {
+  const values = new Map<string, string>()
+  if (cached)
+    values.set(
+      key,
+      JSON.stringify({
+        feed: cached.feed ?? sample,
+        checkedAt: now - (cached.age ?? 0),
+        etag: '"version-one"',
+      })
+    )
+  const storage = {
+    getString: (key: string) => values.get(key),
+    set: (key: string, value: string) => {
+      values.set(key, value)
+    },
+  }
+  const fetcher = vi
+    .fn<typeof fetch>()
+    .mockResolvedValue(
+      Response.json(sample, { headers: { ETag: '"version-two"' } })
+    )
+  const create = () =>
+    createAnnouncementClient({
+      endpoint,
+      storage,
+      fetch: fetcher,
+      now: () => Date.now(),
+    })
+  vi.spyOn(Date, 'now').mockReturnValue(now)
+  return { client: create(), create, values, fetcher, storage }
+}
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('announcement launch/cache contract', () => {
+  it('fetches once and makes a first download visible on the next launch only', async () => {
+    const { client, create, fetcher } = setup()
+    await client.checkForUpdates()
+    await client.checkForUpdates()
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(client.getLaunchAnnouncement()).toBeNull()
+    expect(create().getLaunchAnnouncement()?.id).toBe('qa-help')
+  })
+  it('shows a fresh cached item with no network request', async () => {
+    const { client, fetcher } = setup({})
+    expect(client.getLaunchAnnouncement()?.id).toBe('qa-help')
+    await client.checkForUpdates()
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+  it('revalidates an older cache with ETag and preserves the launch snapshot', async () => {
+    const { client, fetcher, values } = setup({ age: REFRESH_AFTER_MS })
+    fetcher.mockResolvedValue(new Response(null, { status: 304 }))
+    await client.checkForUpdates()
+    expect(fetcher.mock.calls[0][1]).toMatchObject({
+      credentials: 'omit',
+      headers: { 'If-None-Match': '"version-one"' },
+    })
+    expect(JSON.parse(values.get(key)!).checkedAt).toBe(now)
+    expect(client.getLaunchAnnouncement()?.id).toBe('qa-help')
+  })
+  it('withdraws next launch without removing content while someone reads it', async () => {
+    const { client, create, fetcher } = setup({ age: REFRESH_AFTER_MS })
+    fetcher.mockResolvedValue(
+      Response.json({ schemaVersion: 1, announcement: null })
+    )
+    await client.checkForUpdates()
+    expect(client.getLaunchAnnouncement()?.id).toBe('qa-help')
+    expect(create().getLaunchAnnouncement()).toBeNull()
+  })
+  it('does not keep offline announcements indefinitely or send an expired ETag', async () => {
+    const { client, fetcher } = setup({ age: MAX_CACHE_AGE_MS })
+    expect(client.getLaunchAnnouncement()).toBeNull()
+    await client.checkForUpdates()
+    expect(fetcher.mock.calls[0][1]?.headers).toBeUndefined()
+  })
+  it('ignores future cache timestamps after a clock correction', async () => {
+    const { client, fetcher } = setup({ age: -1000 })
+    expect(client.getLaunchAnnouncement()).toBeNull()
+    await client.checkForUpdates()
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+  it.each([
+    () => new Response('unavailable', { status: 503 }),
+    () =>
+      new Response('not json', {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    () => Response.json({ schemaVersion: 2, announcement: null }),
+    () => Response.json({ schemaVersion: 1, announcement: { id: 'bad' } }),
+    () => new Response('<html>portal</html>'),
+  ])(
+    'preserves the bounded cache when the service returns invalid data',
+    async (response) => {
+      const { client, values, fetcher } = setup({ age: REFRESH_AFTER_MS })
+      const before = values.get(key)
+      fetcher.mockResolvedValue(response())
+      await client.checkForUpdates()
+      expect(values.get(key)).toBe(before)
+      expect(client.getLaunchAnnouncement()?.id).toBe('qa-help')
+    }
+  )
+  it('does not retry offline failures', async () => {
+    const { client, fetcher } = setup()
+    fetcher.mockRejectedValue(new TypeError('Network request failed'))
+    await expect(client.checkForUpdates()).resolves.toBeUndefined()
+    await client.checkForUpdates()
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+  it('aborts a slow request after five seconds', async () => {
+    vi.useFakeTimers()
+    const { client, fetcher } = setup()
+    fetcher.mockImplementation(
+      (_url, options) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () =>
+            reject(new Error('aborted'))
+          )
+        })
+    )
+    const request = client.checkForUpdates()
+    await vi.advanceTimersByTimeAsync(5000)
+    await expect(request).resolves.toBeUndefined()
+    expect(fetcher.mock.calls[0][1]?.signal?.aborted).toBe(true)
+  })
+  it('cancels pending reads when the app backgrounds and ignores late data', async () => {
+    const { client, values, fetcher } = setup()
+    let resolve!: (response: Response) => void
+    fetcher.mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done
+        })
+    )
+    const controller = new AbortController()
+    const request = client.checkForUpdates(controller.signal)
+    controller.abort()
+    resolve(Response.json(sample))
+    await request
+    expect(values.size).toBe(0)
+  })
+  it('persists dismissal by identity across edits but displays a new identity', () => {
+    const { client, create, values } = setup({})
+    client.dismiss('qa-help')
+    expect(create().getLaunchAnnouncement()).toBeNull()
+    const feed = structuredClone(sample)
+    feed.announcement!.revision = 'c8852953-d94e-45f0-8bca-cf7e7f00b1c8'
+    values.set(key, JSON.stringify({ feed, checkedAt: now }))
+    expect(create().getLaunchAnnouncement()).toBeNull()
+    feed.announcement!.id = 'happy-service-year'
+    values.set(key, JSON.stringify({ feed, checkedAt: now }))
+    expect(create().getLaunchAnnouncement()?.id).toBe('happy-service-year')
+  })
+  it('honors start and expiration even while offline', () => {
+    const feed = structuredClone(sample)
+    feed.announcement!.startsAt = '2026-09-06T00:00:00Z'
+    expect(setup({ feed }).client.getLaunchAnnouncement()).toBeNull()
+    feed.announcement!.startsAt = '2026-09-04T00:00:00Z'
+    feed.announcement!.expiresAt = '2026-09-05T12:00:00Z'
+    expect(setup({ feed }).client.getLaunchAnnouncement()).toBeNull()
+  })
+  it('isolates development and production caches', () => {
+    const { storage } = setup({})
+    const dev = createAnnouncementClient({
+      endpoint: 'http://localhost:8787/announcements/current.json',
+      storage,
+    })
+    expect(dev.getLaunchAnnouncement()).toBeNull()
+  })
+})
+
+describe('localized content and links', () => {
+  it('resolves inline and reference images without rewriting absolute links', () => {
+    const path = `/announcements/images/${'a'.repeat(64)}.png`
+    const markdown = `![Photo](${path})\n![Photo][picture]\n[picture]: <${path}>\n[Link](https://example.org${path})`
+    const resolved = resolveAnnouncementImages(markdown, endpoint)
+    expect(resolved).toContain(`![Photo](https://example.com${path})`)
+    expect(resolved).toContain(`[picture]: <https://example.com${path}>`)
+    expect(resolved).toContain(`[Link](https://example.org${path})`)
+  })
+  it('preserves Chinese script choice and falls back to English for missing translations', () => {
+    const announcement = structuredClone(sample.announcement!)
+    announcement.locales['zh-hant-tw'] = {
+      bannerText: '公告',
+      title: '公告',
+      markdown: '繁體中文',
+    }
+    expect(announcementContent(announcement, 'zh-TW').markdown).toBe('繁體中文')
+    expect(announcementContent(announcement, 'zh-CN')).toEqual(
+      announcement.locales['en-us']
+    )
+    expect(announcementContent(announcement, 'fr-fr')).toEqual(
+      announcement.locales['en-us']
+    )
+  })
+  it.each([
+    'javascript:alert(1)',
+    'file:///etc/passwd',
+    'witnesswork://import',
+    'http://example.com',
+    'https://user:password@example.com',
+    ' https://example.com',
+    'https://example.com\n',
+  ])('rejects unsafe link %s', (url) => {
+    expect(safeAnnouncementLink(url)).toBe(false)
+  })
+  it.each([
+    'https://example.com/signup?source=app',
+    'mailto:levi@example.com?subject=QA%20help',
+  ])('allows informational link %s', (url) => {
+    expect(safeAnnouncementLink(url)).toBe(true)
+  })
+})

--- a/src/features/announcements/lib/announcementClient.ts
+++ b/src/features/announcements/lib/announcementClient.ts
@@ -1,0 +1,161 @@
+import {
+  announcementFeedSchema,
+  isAnnouncementActive,
+  MAX_CACHE_AGE_MS,
+  MAX_FEED_BYTES,
+  REFRESH_AFTER_MS,
+  type AnnouncementFeed,
+} from '@/features/announcements/lib/announcement'
+
+interface Storage {
+  getString(key: string): string | undefined
+  set(key: string, value: string): void
+}
+
+interface CachedFeed {
+  feed: AnnouncementFeed
+  checkedAt: number
+  etag?: string
+}
+
+/** One launch snapshot, one optional request, and a bounded offline cache. */
+export function createAnnouncementClient({
+  endpoint,
+  storage,
+  fetch: fetchFeed = fetch,
+  now = Date.now,
+}: {
+  endpoint: string
+  storage: Storage
+  fetch?: typeof fetch
+  now?: () => number
+}) {
+  // Namespace by endpoint so changing between development and production never
+  // displays content from the other environment.
+  const cacheKey = `announcements:v1:${endpoint}`
+  const dismissKey = `${cacheKey}:dismissed`
+  let didCheck = false
+  let launchCache: CachedFeed | null | undefined
+
+  function readCache(): CachedFeed | null {
+    try {
+      const raw = storage.getString(cacheKey)
+      if (!raw || raw.length > MAX_FEED_BYTES + 1024) return null
+      const value = JSON.parse(raw)
+      const parsed = announcementFeedSchema.safeParse(value.feed)
+      if (!parsed.success || !Number.isFinite(value.checkedAt)) return null
+      if (
+        value.checkedAt > now() ||
+        now() - value.checkedAt >= MAX_CACHE_AGE_MS
+      )
+        return null
+      return {
+        feed: parsed.data,
+        checkedAt: value.checkedAt,
+        etag:
+          typeof value.etag === 'string' && value.etag.length < 200
+            ? value.etag
+            : undefined,
+      }
+    } catch {
+      return null
+    }
+  }
+
+  function dismissedIds(): string[] {
+    try {
+      const value = JSON.parse(storage.getString(dismissKey) ?? '[]')
+      return Array.isArray(value)
+        ? value.filter((id) => typeof id === 'string').slice(-100)
+        : []
+    } catch {
+      return []
+    }
+  }
+
+  function getLaunchAnnouncement() {
+    if (launchCache === undefined) launchCache = readCache()
+    if (!launchCache || now() - launchCache.checkedAt >= MAX_CACHE_AGE_MS)
+      return null
+    const announcement = launchCache.feed.announcement
+    if (
+      !announcement ||
+      !isAnnouncementActive(announcement, now()) ||
+      dismissedIds().includes(announcement.id)
+    )
+      return null
+    return announcement
+  }
+
+  function dismiss(id: string) {
+    try {
+      storage.set(
+        dismissKey,
+        JSON.stringify(
+          [...dismissedIds().filter((value) => value !== id), id].slice(-100)
+        )
+      )
+    } catch {
+      // The component still hides it for this session if storage is unavailable.
+    }
+  }
+
+  async function checkForUpdates(signal?: AbortSignal): Promise<void> {
+    if (didCheck || signal?.aborted) return
+    didCheck = true
+    // Freeze before writing, even when Home hasn't mounted yet (deep link or
+    // another default tab). Late responses can never insert a banner this run.
+    getLaunchAnnouncement()
+    const cached = readCache()
+    if (cached && now() - cached.checkedAt < REFRESH_AFTER_MS) return
+
+    const controller = new AbortController()
+    const abort = () => controller.abort()
+    signal?.addEventListener('abort', abort, { once: true })
+    const timeout = setTimeout(abort, 5_000)
+    try {
+      const response = await fetchFeed(endpoint, {
+        signal: controller.signal,
+        credentials: 'omit',
+        headers: cached?.etag ? { 'If-None-Match': cached.etag } : undefined,
+      })
+      if (controller.signal.aborted) return
+      if (response.status === 304 && cached) {
+        storage.set(cacheKey, JSON.stringify({ ...cached, checkedAt: now() }))
+        return
+      }
+      if (
+        !response.ok ||
+        Number(response.headers.get('Content-Length')) > MAX_FEED_BYTES
+      )
+        return
+      if (!response.headers.get('Content-Type')?.includes('application/json'))
+        return
+      const raw = await response.text()
+      if (
+        controller.signal.aborted ||
+        raw.length > MAX_FEED_BYTES ||
+        new TextEncoder().encode(raw).byteLength > MAX_FEED_BYTES
+      )
+        return
+      const parsed = announcementFeedSchema.safeParse(JSON.parse(raw))
+      if (!parsed.success) return
+      storage.set(
+        cacheKey,
+        JSON.stringify({
+          feed: parsed.data,
+          checkedAt: now(),
+          etag: response.headers.get('ETag') ?? undefined,
+        })
+      )
+    } catch {
+      // Informational only: no retries, alerts, loading UI, or error reporting
+      // for offline, timeout, malformed remote data, or local storage failures.
+    } finally {
+      clearTimeout(timeout)
+      signal?.removeEventListener('abort', abort)
+    }
+  }
+
+  return { getLaunchAnnouncement, dismiss, checkForUpdates }
+}

--- a/src/features/announcements/lib/announcementRuntime.ts
+++ b/src/features/announcements/lib/announcementRuntime.ts
@@ -1,0 +1,8 @@
+import apis from '@/constants/apis'
+import { mmkvStorage } from '@/stores/mmkv'
+import { createAnnouncementClient } from '@/features/announcements/lib/announcementClient'
+
+export const announcementClient = createAnnouncementClient({
+  endpoint: apis.announcements,
+  storage: mmkvStorage,
+})

--- a/src/features/home/screens/HomeScreen.tsx
+++ b/src/features/home/screens/HomeScreen.tsx
@@ -47,6 +47,7 @@ import { HomeTabStackNavigation } from '@/types/homeStack'
 import { RootStackNavigation } from '@/types/rootStack'
 import { Fragment } from 'react'
 import type { TimeEntry } from '@/types/timeEntry'
+import AnnouncementBanner from '@/features/announcements/components/AnnouncementBanner'
 
 export const HomeScreen = () => {
   const theme = useTheme()
@@ -326,6 +327,7 @@ export const HomeScreen = () => {
         }
       >
         <View style={{ gap: 20, paddingBottom: insets.bottom, flex: 1 }}>
+          <AnnouncementBanner />
           <ProfileCard
             onPressIncomplete={() =>
               rootNavigation.navigate('PreferencesPublisher')

--- a/src/features/notes-import/hooks/useNotesImportAvailability.ts
+++ b/src/features/notes-import/hooks/useNotesImportAvailability.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import Constants from 'expo-constants'
 import { create } from 'zustand'
+import { beginStartupWork } from '@/lib/deferUntilNotBlocking'
 import { getNotesImportStatus } from '@/features/notes-import/lib/notesImportClient'
 import type { NotesImportPublicSchedule } from '@/features/notes-import/lib/notesImportUsage'
 import {
@@ -42,6 +43,7 @@ const useAvailabilityStore = create<AvailabilityStore>((set) => ({
   loading: true,
 
   probe: async () => {
+    const finishStartup = beginStartupWork()
     const probe = ++latestProbe
     // Access remains fail-open, but schedule claims disappear while this fresh
     // probe is pending (including when another surface mounts later).
@@ -52,7 +54,9 @@ const useAvailabilityStore = create<AvailabilityStore>((set) => ({
       updateRequired: null,
       loading: true,
     })
-    const status = await getNotesImportStatus().catch(() => null)
+    const status = await getNotesImportStatus()
+      .catch(() => null)
+      .finally(finishStartup)
     if (probe !== latestProbe) return
 
     if (!status) {

--- a/src/lib/deferUntilNotBlocking.test.ts
+++ b/src/lib/deferUntilNotBlocking.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const app = vi.hoisted(() => ({
+  currentState: 'active',
+  handlers: new Set<() => void>(),
+}))
+vi.mock('react-native', () => ({
+  AppState: {
+    get currentState() {
+      return app.currentState
+    },
+    addEventListener: (_event: string, listener: () => void) => {
+      app.handlers.add(listener)
+      return { remove: () => app.handlers.delete(listener) }
+    },
+  },
+}))
+import {
+  beginStartupWork,
+  deferUntilNotBlocking,
+} from '@/lib/deferUntilNotBlocking'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  app.currentState = 'active'
+  vi.stubGlobal('requestAnimationFrame', (callback: () => void) =>
+    setTimeout(callback, 16)
+  )
+  vi.stubGlobal('cancelAnimationFrame', clearTimeout)
+  vi.stubGlobal('requestIdleCallback', (callback: () => void) =>
+    setTimeout(callback, 1)
+  )
+  vi.stubGlobal('cancelIdleCallback', clearTimeout)
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('deferUntilNotBlocking', () => {
+  it('waits for every startup task, two frames, and idle before running once', async () => {
+    const finishRevenueCat = beginStartupWork()
+    const finishNotes = beginStartupWork()
+    const task = vi.fn()
+    deferUntilNotBlocking(task)
+    await vi.advanceTimersByTimeAsync(2000)
+    finishRevenueCat()
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(task).not.toHaveBeenCalled()
+    finishNotes()
+    await vi.advanceTimersByTimeAsync(1032)
+    expect(task).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(task).toHaveBeenCalledTimes(1)
+    finishNotes()
+    await vi.advanceTimersByTimeAsync(40_000)
+    expect(task).toHaveBeenCalledTimes(1)
+    expect(app.handlers.size).toBe(0)
+  })
+  it('rechecks blockers registered between render and the idle callback', async () => {
+    const task = vi.fn()
+    deferUntilNotBlocking(task)
+    await vi.advanceTimersByTimeAsync(1020)
+    const finish = beginStartupWork()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(task).not.toHaveBeenCalled()
+    finish()
+    await vi.advanceTimersByTimeAsync(1033)
+    expect(task).toHaveBeenCalledTimes(1)
+  })
+  it('waits for foreground and can be cancelled before any work starts', async () => {
+    app.currentState = 'background'
+    const task = vi.fn()
+    const controller = new AbortController()
+    deferUntilNotBlocking(task, { signal: controller.signal })
+    await vi.advanceTimersByTimeAsync(2000)
+    app.currentState = 'active'
+    app.handlers.forEach((handler) => handler())
+    controller.abort()
+    await vi.advanceTimersByTimeAsync(40_000)
+    expect(task).not.toHaveBeenCalled()
+    expect(app.handlers.size).toBe(0)
+  })
+  it('skips a hung startup instead of forcing optional work', async () => {
+    const finish = beginStartupWork()
+    const task = vi.fn()
+    deferUntilNotBlocking(task)
+    await vi.advanceTimersByTimeAsync(30_000)
+    finish()
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(task).not.toHaveBeenCalled()
+    expect(app.handlers.size).toBe(0)
+  })
+})

--- a/src/lib/deferUntilNotBlocking.ts
+++ b/src/lib/deferUntilNotBlocking.ts
@@ -1,0 +1,74 @@
+import { AppState } from 'react-native'
+
+const pending = new Set<symbol>()
+const listeners = new Set<() => void>()
+
+/** Register startup work before starting it; always release it in finally. */
+export function beginStartupWork(): () => void {
+  const id = Symbol('startup')
+  pending.add(id)
+  listeners.forEach((listener) => listener())
+  return () => {
+    if (!pending.delete(id)) return
+    listeners.forEach((listener) => listener())
+  }
+}
+
+/**
+ * Best-effort foreground work after rendering and registered startup work.
+ * React Native's idle callback alone does not wait for async initialization. A
+ * busy/hung launch skips optional work after 30 seconds instead of forcing it
+ * into a frame. The caller owns errors and cancellation of an in-flight task.
+ */
+export function deferUntilNotBlocking(
+  task: () => void,
+  { signal }: { signal?: AbortSignal } = {}
+): () => void {
+  if (signal?.aborted) return () => {}
+  let stopped = false
+  let frame: number | undefined
+  let idle: number | undefined
+  let quiet: ReturnType<typeof setTimeout> | undefined
+
+  const cancelScheduled = () => {
+    if (frame !== undefined) cancelAnimationFrame(frame)
+    if (idle !== undefined) cancelIdleCallback(idle)
+    if (quiet !== undefined) clearTimeout(quiet)
+    frame = idle = quiet = undefined
+  }
+  const eligible = () =>
+    pending.size === 0 && AppState.currentState === 'active'
+  const cleanup = () => {
+    if (stopped) return
+    stopped = true
+    cancelScheduled()
+    clearTimeout(deadline)
+    listeners.delete(schedule)
+    subscription.remove()
+    signal?.removeEventListener('abort', cleanup)
+  }
+  const schedule = () => {
+    cancelScheduled()
+    if (stopped || !eligible()) return
+    // Let React effects and follow-up startup tasks settle, then yield two
+    // frames before requesting idle time. Never give the idle callback a
+    // timeout: that would force optional work during a busy frame.
+    quiet = setTimeout(() => {
+      frame = requestAnimationFrame(() => {
+        frame = requestAnimationFrame(() => {
+          idle = requestIdleCallback(() => {
+            if (!eligible() || signal?.aborted) return schedule()
+            cleanup()
+            task()
+          })
+        })
+      })
+    }, 1_000)
+  }
+  const subscription = AppState.addEventListener('change', schedule)
+  const deadline = setTimeout(cleanup, 30_000)
+  listeners.add(schedule)
+  signal?.addEventListener('abort', cleanup, { once: true })
+  schedule()
+  return cleanup
+}

--- a/src/providers/AccountProvider.tsx
+++ b/src/providers/AccountProvider.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/lib/account'
 import { logger } from '@/lib/logger'
 import { isOfflineError } from '@/lib/offlineError'
+import { beginStartupWork } from '@/lib/deferUntilNotBlocking'
 
 interface Props {}
 
@@ -83,6 +84,7 @@ const AccountProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
         return
       }
       inFlightRef.current = true
+      const finishStartup = beginStartupWork()
       try {
         if (!ICloudBridge.isAvailable()) {
           setICloudSharingAvailable(false)
@@ -172,6 +174,7 @@ const AccountProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
           Sentry.captureException(error)
         }
       } finally {
+        finishStartup()
         inFlightRef.current = false
         const queued = queuedReasonRef.current
         queuedReasonRef.current = null

--- a/src/providers/CustomerProvider.tsx
+++ b/src/providers/CustomerProvider.tsx
@@ -12,6 +12,7 @@ import * as Sentry from '@sentry/react-native'
 import { logger } from '@/lib/logger'
 import { isOfflineError } from '@/lib/offlineError'
 import { getOrCreateAccountId } from '@/lib/account'
+import { beginStartupWork } from '@/lib/deferUntilNotBlocking'
 
 interface Props {}
 
@@ -44,6 +45,7 @@ const CustomerProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
   useEffect(() => {
     if (hasInitialized.current) return
     hasInitialized.current = true
+    const finishStartup = beginStartupWork()
 
     // `configure` returns void synchronously; `setLogLevel` is fire-and-forget.
     // Flip `ready` immediately after so downstream screens can fetch offerings.
@@ -60,6 +62,7 @@ const CustomerProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
       )
       logger.error(error.message)
       Sentry.captureException(error)
+      finishStartup()
       return
     }
 
@@ -94,6 +97,7 @@ const CustomerProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
       // will fail, but the rest of the app should still load.
       logger.error('[CustomerProvider] Purchases.configure threw', error)
       Sentry.captureException(error)
+      finishStartup()
       return
     }
 
@@ -119,20 +123,22 @@ const CustomerProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
         })
       : Purchases.getCustomerInfo().then(seedCustomer)
 
-    identify.catch((error) => {
-      if (accountId && !isOfflineError(error)) {
-        logger.warn('[CustomerProvider] Purchases.logIn failed', error)
-        Sentry.captureException(error)
-      } else {
-        logger.warn('[CustomerProvider] initial customer info failed', error)
-      }
-      // Last-resort fall back to whatever CustomerInfo the SDK has cached.
-      if (accountId) {
-        Purchases.getCustomerInfo()
-          .then(seedCustomer)
-          .catch(() => {})
-      }
-    })
+    identify
+      .catch(async (error) => {
+        if (accountId && !isOfflineError(error)) {
+          logger.warn('[CustomerProvider] Purchases.logIn failed', error)
+          Sentry.captureException(error)
+        } else {
+          logger.warn('[CustomerProvider] initial customer info failed', error)
+        }
+        // Last-resort fall back to whatever CustomerInfo the SDK has cached.
+        if (accountId) {
+          await Purchases.getCustomerInfo()
+            .then(seedCustomer)
+            .catch(() => {})
+        }
+      })
+      .finally(finishStartup)
   }, [])
 
   const hasPurchasedBefore = useMemo(


### PR DESCRIPTION
Adds one cached announcement above Home with a native Markdown detail sheet, images, links, optional Levi signature, and persistent dismissal. A single optional feed check runs after navigation and startup services settle; downloaded content appears on the next launch to avoid layout shifts. Includes locale fallback, expiry, ETags, and bounded offline behavior.

Companion backend: https://github.com/leviFrosty/ww-api/pull/6 provides R2 publishing and a local rich-text editor with Codex/Claude translation. **Ship in a new iOS binary:** the Markdown renderer adds native code and must not be delivered as an OTA update to an existing runtime.
