### PR TITLE
fix(service-reports): separate Hourglass preaching time from credit

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@tamagui/babel-plugin": "^2.4.2",
     "@types/lodash": "^4.17.24",
     "@types/react": "~19.2.17",
+    "@types/react-dom": "^19.2.5",
     "@types/react-test-renderer": "^19.1.0",
     "@types/semver": "^7.7.1",
     "baseline-browser-mapping": "^2.10.40",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
       '@types/react':
         specifier: ~19.2.17
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.5
+        version: 19.2.5(@types/react@19.2.17)
       '@types/react-test-renderer':
         specifier: ^19.1.0
         version: 19.1.0
@@ -3962,6 +3965,14 @@ packages:
       {
         integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==,
       }
+
+  '@types/react-dom@19.2.5':
+    resolution:
+      {
+        integrity: sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==,
+      }
+    peerDependencies:
+      '@types/react': ^19.2.0
 
   '@types/react-test-renderer@19.1.0':
     resolution:
@@ -15294,6 +15305,10 @@ snapshots:
   '@types/node@26.2.0':
     dependencies:
       undici-types: 8.3.0
+
+  '@types/react-dom@19.2.5(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
 
   '@types/react-test-renderer@19.1.0':
     dependencies:

--- a/src/__tests__/useMonthReportData.test.ts
+++ b/src/__tests__/useMonthReportData.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import useMonthReportData, {
+  type MonthReportData,
+} from '@/features/service-reports/hooks/useMonthReportData'
+import { buildHourglassLink } from '@/features/service-reports/lib/submitLinks'
+import type { TimeEntry } from '@/types/timeEntry'
+import type { Publisher } from '@/types/publisher'
+
+const fixture = vi.hoisted(() => ({
+  entries: [] as TimeEntry[],
+  role: 'regularPioneer' as Publisher,
+  reportCommentOverrides: {} as Record<string, string>,
+}))
+
+vi.mock('@/stores/preferences', () => ({
+  usePreferences: () => ({
+    role: fixture.role,
+    publisherHours: { regularPioneer: 50, publisher: 0 },
+    userSpecifiedHasAnnualGoal: 'default',
+    milestoneOverrides: null,
+    overrideCreditLimit: false,
+    customCreditLimitHours: 55,
+    reportCommentOverrides: fixture.reportCommentOverrides,
+  }),
+}))
+vi.mock('@/stores/serviceReport', () => ({
+  default: () => ({ serviceReports: { 2026: { 7: fixture.entries } } }),
+}))
+vi.mock('@/stores/categories', () => ({
+  default: () => ({
+    categories: [{ id: 'bethel', name: 'Bethel', isCredit: true }],
+  }),
+}))
+vi.mock('@/stores/conversationStore', () => ({
+  default: () => ({ conversations: [] }),
+}))
+vi.mock('@/stores/contactsStore', () => ({
+  default: () => ({ contacts: [] }),
+}))
+vi.mock('@/lib/locales', async () => {
+  const { I18n } = await import('i18n-js')
+  const { default: en } = await import('@/locales/en-US.json')
+  return { default: new I18n({ en }, { locale: 'en' }) }
+})
+
+const checkReport = (check: (data: MonthReportData) => void) => {
+  function Probe() {
+    check(useMonthReportData(7, 2026))
+    return null
+  }
+  renderToStaticMarkup(createElement(Probe))
+}
+
+const entry = (hours: number, credit = false): TimeEntry => ({
+  id: credit ? 'credit' : 'preaching',
+  date: new Date(2026, 7, 10, 12),
+  hours,
+  minutes: 0,
+  ...(credit ? { categoryId: 'bethel', credit: true } : {}),
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 8, 5, 12))
+  fixture.entries = []
+  fixture.role = 'regularPioneer'
+  fixture.reportCommentOverrides = {}
+})
+afterEach(() => vi.useRealTimers())
+
+describe('Hourglass report data', () => {
+  it.each([
+    { preaching: 30, credit: 10, applied: 10 },
+    { preaching: 1, credit: 1, applied: 1 },
+    { preaching: 30, credit: 40, applied: 25 },
+    { preaching: 60, credit: 10, applied: 0 },
+    { preaching: 0, credit: 10, applied: 10 },
+    { preaching: 1, credit: 0, applied: 0 },
+  ])(
+    'exports $preaching preaching hours separately from $credit credit hours',
+    ({ preaching, credit, applied }) => {
+      fixture.entries = [entry(preaching), entry(credit, true)]
+      checkReport((data) => {
+        expect(data.hours).toBe(preaching)
+        expect(data.credit).toBe(applied)
+        const url = new URL(
+          buildHourglassLink({
+            month: 8,
+            year: 2026,
+            ...data.hourglassReport,
+          })
+        )
+        expect(url.searchParams.get('minutes')).toBe(String(preaching * 60))
+        if (credit > 0) {
+          expect(url.searchParams.get('remarks')).toContain(
+            `Bethel: ${credit}h`
+          )
+          expect(url.searchParams.get('remarks')).toContain(
+            `Credit shown on report: ${applied}h`
+          )
+        }
+      })
+    }
+  )
+
+  it('preserves preaching minutes without rounding them to whole hours', () => {
+    fixture.entries = [{ ...entry(1), minutes: 30 }, entry(1, true)]
+    checkReport((data) => expect(data.hourglassReport.minutes).toBe(90))
+  })
+
+  it.each([false, true])(
+    'preserves the checkbox participation indicator: %s',
+    (shared) => {
+      fixture.role = 'publisher'
+      fixture.entries = shared ? [entry(0)] : []
+      checkReport((data) =>
+        expect(data.hourglassReport.minutes).toBe(shared ? 1 : 0)
+      )
+    }
+  )
+
+  it('keeps credit overage in the Hourglass remarks', () => {
+    fixture.entries = [entry(30), entry(40, true)]
+    checkReport((data) => {
+      expect(data.hourglassReport.remarks).toBe(data.defaultNotes)
+      expect(data.hourglassReport.remarks).toContain(
+        'Credit shown on report: 25h'
+      )
+      expect(data.hourglassReport.remarks).toContain('Not applied: 15h')
+    })
+  })
+
+  it.each(['User comment & details', ''])(
+    'respects a saved report comment override: %j',
+    (comment) => {
+      fixture.entries = [entry(30), entry(10, true)]
+      fixture.reportCommentOverrides = { '2026-08': comment }
+      checkReport((data) => {
+        const url = new URL(
+          buildHourglassLink({ month: 8, year: 2026, ...data.hourglassReport })
+        )
+        expect(url.searchParams.get('minutes')).toBe('1800')
+        expect(url.searchParams.get('remarks')).toBe(comment || null)
+      })
+    }
+  )
+})

--- a/src/features/service-reports/hooks/useMonthReportData.ts
+++ b/src/features/service-reports/hooks/useMonthReportData.ts
@@ -15,6 +15,7 @@ import {
 } from '@/lib/serviceReport'
 import { getStudiesForGivenMonth } from '@/lib/contacts'
 import { formatMinutesCompact } from '@/lib/minutes'
+import type { HourglassReport } from '@/features/service-reports/lib/submitLinks'
 
 export type MonthReportData = {
   /** Whether the publisher has any reports logged for this month. */
@@ -27,10 +28,10 @@ export type MonthReportData = {
   creditOverageHours: number
   studies: number | null
   /**
-   * Minutes value for Hourglass submission: total adjusted minutes for hourly
-   * publishers, or 1/0 (shared / didn't share) for checkbox-mode publishers.
+   * Hourglass submission fields. Preaching minutes and Credit Time remarks stay
+   * separate; checkbox mode uses 1/0 for participation.
    */
-  hourglassMinutes: number
+  hourglassReport: Pick<HourglassReport, 'minutes' | 'studies' | 'remarks'>
   /**
    * Comments text for the report. The auto-generated credit breakdown, unless
    * the user saved a month-specific override (see `hasNotesOverride`).
@@ -120,7 +121,7 @@ const useMonthReportData = (
   const credit = Math.max(0, Math.floor(adjusted.value / 60) - hours)
   const creditOverageHours = Math.floor(adjusted.creditOverage / 60)
   const hourglassMinutes =
-    entryMode === 'checkbox' ? (sharedInMinistry ? 1 : 0) : adjusted.value
+    entryMode === 'checkbox' ? (sharedInMinistry ? 1 : 0) : adjusted.standard
 
   const defaultNotes = useMemo(() => {
     if (month === undefined || year === undefined) return ''
@@ -204,7 +205,11 @@ const useMonthReportData = (
     credit,
     creditOverageHours,
     studies,
-    hourglassMinutes,
+    hourglassReport: {
+      minutes: hourglassMinutes,
+      studies,
+      remarks: notes || undefined,
+    },
     notes,
     defaultNotes,
     hasNotesOverride,

--- a/src/features/service-reports/lib/submitLinks.ts
+++ b/src/features/service-reports/lib/submitLinks.ts
@@ -48,11 +48,12 @@ export type HourglassReport = {
   month: number
   year: number
   /**
-   * Total ministry minutes. Checkbox-mode publishers send 1 to indicate sharing
-   * in the ministry.
+   * Preaching minutes, excluding Credit Time. Checkbox-mode publishers send 1
+   * to indicate sharing in the ministry.
    */
   minutes: number
   studies?: number | null
+  /** Credit Time breakdown or the user's report comment override. */
   remarks?: string
 }
 

--- a/src/features/service-reports/screens/ServiceReportViewScreen.tsx
+++ b/src/features/service-reports/screens/ServiceReportViewScreen.tsx
@@ -280,7 +280,8 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
         return
       }
 
-      // A user-edited comment replaces the auto-generated overage remark.
+      // NW Publisher has a separate credit field, so its default remark only
+      // needs the overage. Hourglass carries the credit breakdown in remarks.
       const remarks = data.hasNotesOverride
         ? data.notes || undefined
         : data.creditOverageHours > 0
@@ -294,9 +295,7 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
           buildHourglassLink({
             month: month + 1,
             year,
-            minutes: data.hourglassMinutes,
-            studies: data.studies,
-            remarks,
+            ...data.hourglassReport,
           })
         )
         confirmSubmission()


### PR DESCRIPTION
Hourglass now receives preaching minutes separately from Credit Time: a report with 30 preaching hours and 10 credit hours sends `minutes=1800`, with the credit breakdown in `remarks`. Preserves credit-cap details, fractional preaching minutes, checkbox participation, and saved comment overrides. Refs #456.

Draft pending Hourglass iOS verification: confirm the outgoing report shows the intended preaching total and separate Credit Time remarks, and confirm whether the submission link supports a dedicated numeric credit field. This change uses the support-confirmed `remarks` parameter; it does not claim to prefill Hourglass's numeric credit field.
