### PR TITLE
Add Schedule Screen preferences to restore the calendar Assistant

### DIFF
--- a/src/app/navigation/RootStack.tsx
+++ b/src/app/navigation/RootStack.tsx
@@ -24,6 +24,7 @@ import PreferencesPublisherScreen from '@/features/settings/screens/preferences/
 import PreferencesConversationScreen from '@/features/settings/screens/preferences/screens/PreferencesConversationScreen'
 import PreferencesPlansScreen from '@/features/settings/screens/preferences/screens/PreferencesPlansScreen'
 import PreferencesNavigationScreen from '@/features/settings/screens/preferences/screens/PreferencesNavigationScreen'
+import PreferencesScheduleScreen from '@/features/settings/screens/preferences/screens/PreferencesScheduleScreen'
 import PreferencesHomeScreen from '@/features/settings/screens/preferences/screens/PreferencesHomeScreen'
 import PreferencesBackupsScreen from '@/features/settings/screens/preferences/screens/PreferencesBackupsScreen'
 import PreferencesAppearanceScreen from '@/features/settings/screens/preferences/screens/PreferencesAppearanceScreen'
@@ -238,6 +239,18 @@ const RootStackComponent = () => {
           }}
           name='PreferencesHomeScreen'
           component={PreferencesHomeScreen}
+        />
+        <RootStack.Screen
+          options={{
+            header: () => (
+              <Header
+                buttonType='back'
+                title={i18n.t('milestoneSecondary_schedule_title')}
+              />
+            ),
+          }}
+          name='PreferencesScheduleScreen'
+          component={PreferencesScheduleScreen}
         />
         <RootStack.Screen
           options={{

--- a/src/components/AssistantSection.tsx
+++ b/src/components/AssistantSection.tsx
@@ -61,6 +61,8 @@ type Props = {
    * its container (e.g. its own Card).
    */
   standalone?: boolean
+  /** When provided, the parent owns visibility instead of the saved input hash. */
+  onDismiss?: () => void
 }
 
 const ASSISTANT_VISIBLE_STATES: ReadonlySet<ProjectedTotalState> = new Set([
@@ -76,6 +78,7 @@ const AssistantSection = ({
   monthlyGoalHours,
   projection,
   standalone = false,
+  onDismiss,
 }: Props) => {
   const theme = useTheme()
   const navigation = useNavigation<RootStackNavigation>()
@@ -207,12 +210,14 @@ const AssistantSection = ({
       action: 'dismissed',
       at: Date.now(),
     })
-    setHasDismissedRecommendationHash(inputsHash)
+    if (onDismiss) onDismiss()
+    else setHasDismissedRecommendationHash(inputsHash)
   }, [
     recommendation,
     recordAssistantEvent,
     setHasDismissedRecommendationHash,
     inputsHash,
+    onDismiss,
   ])
 
   const handleAccepted = useCallback(() => {
@@ -280,7 +285,7 @@ const AssistantSection = ({
     )
   }
 
-  if (isDismissedForCurrentInputs) return null
+  if (!onDismiss && isDismissedForCurrentInputs) return null
 
   // Pre-onboarding: show an explicit CTA instead of instantly prompting for
   // unavailable days. The user opts in by tapping "Set up Assistant".

--- a/src/features/plans/components/ScheduleScreenSections.tsx
+++ b/src/features/plans/components/ScheduleScreenSections.tsx
@@ -1,0 +1,70 @@
+import AssistantSection from '@/components/AssistantSection'
+import useMonthlyGoal from '@/hooks/useMonthlyGoal'
+import useProjectedTotal from '@/hooks/useProjectedTotal'
+import { getPeriodTense } from '@/lib/projectedTotalCopy'
+import { getEffectiveScheduleScreenOrder } from '@/lib/scheduleScreenPreferences'
+import { usePreferences } from '@/stores/preferences'
+
+const ScheduleScreenSections = ({
+  month,
+  year,
+}: {
+  month: number
+  year: number
+}) => {
+  const preferences = usePreferences()
+  return getEffectiveScheduleScreenOrder(
+    preferences.scheduleScreenElementsOrder
+  ).map((key) => {
+    switch (key) {
+      case 'assistant':
+        return preferences.scheduleScreenElements.assistant ? (
+          <MonthAssistantCard key={key} month={month} year={year} />
+        ) : null
+    }
+  })
+}
+
+const MonthAssistantCard = ({
+  month,
+  year,
+}: {
+  month: number
+  year: number
+}) => {
+  const { set } = usePreferences()
+  const { effectiveGoalHours: monthlyGoalHours } = useMonthlyGoal({
+    month,
+    year,
+  })
+
+  const { projection, today } = useProjectedTotal(
+    { kind: 'month', month, year },
+    monthlyGoalHours * 60
+  )
+
+  const tense = getPeriodTense({ kind: 'month', month, year }, today)
+
+  if (monthlyGoalHours <= 0 || tense === 'past') return null
+
+  return (
+    <AssistantSection
+      year={year}
+      month={month}
+      today={today}
+      monthlyGoalHours={monthlyGoalHours}
+      projection={projection}
+      standalone
+      onDismiss={() =>
+        set((state) => ({
+          scheduleScreenElements: {
+            ...state.scheduleScreenElements,
+            assistant: false,
+          },
+        }))
+      }
+    />
+  )
+}
+
+export default ScheduleScreenSections

--- a/src/features/plans/screens/ScheduleScreen.tsx
+++ b/src/features/plans/screens/ScheduleScreen.tsx
@@ -21,9 +21,7 @@ import {
   getEffectiveStartTimeInMinutesForRecurringPlan,
   RecurringPlan,
 } from '@/lib/recurrence'
-import { getPeriodTense } from '@/lib/projectedTotalCopy'
 import usePublisher from '@/hooks/usePublisher'
-import useProjectedTotal from '@/hooks/useProjectedTotal'
 import {
   getStartTimeInMinutes,
   isStoredDateOnLocalDay,
@@ -36,7 +34,7 @@ import SwipeMonthNavigator from '@/components/SwipeMonthNavigator'
 import CalendarHeader, { CalendarViewMode } from '@/components/CalendarHeader'
 import CalendarKey from '@/features/plans/components/CalendarKey'
 import MonthTimeReportsCalendar from '@/features/service-reports/components/MonthTimeReportsCalendar'
-import AssistantSection from '@/components/AssistantSection'
+import ScheduleScreenSections from '@/features/plans/components/ScheduleScreenSections'
 import SelectedDateSheet, {
   SelectedDateSheetState,
 } from '@/features/service-reports/components/SelectedDateSheet'
@@ -369,7 +367,7 @@ const ScheduleScreen = ({ route }: Props) => {
               {i18n.t('createPlan')}
             </ActionButton>
           </Card>
-          <MonthAssistantCard month={month} year={year} />
+          <ScheduleScreenSections month={month} year={year} />
           <View style={{ gap: 8 }}>
             <XView style={{ justifyContent: 'space-between' }}>
               <Text
@@ -461,38 +459,5 @@ const navButtonStyle = (theme: ReturnType<typeof useTheme>) => ({
   paddingHorizontal: 15,
   paddingVertical: 5,
 })
-
-const MonthAssistantCard = ({
-  month,
-  year,
-}: {
-  month: number
-  year: number
-}) => {
-  const { effectiveGoalHours: monthlyGoalHours } = useMonthlyGoal({
-    month,
-    year,
-  })
-
-  const { projection, today } = useProjectedTotal(
-    { kind: 'month', month, year },
-    monthlyGoalHours * 60
-  )
-
-  const tense = getPeriodTense({ kind: 'month', month, year }, today)
-
-  if (monthlyGoalHours <= 0 || tense === 'past') return null
-
-  return (
-    <AssistantSection
-      year={year}
-      month={month}
-      today={today}
-      monthlyGoalHours={monthlyGoalHours}
-      projection={projection}
-      standalone
-    />
-  )
-}
 
 export default ScheduleScreen

--- a/src/features/settings/components/preferences-sections/ScheduleScreenPreferencesSection.tsx
+++ b/src/features/settings/components/preferences-sections/ScheduleScreenPreferencesSection.tsx
@@ -1,0 +1,95 @@
+import { ArrowDown, ArrowUp } from 'lucide-react-native'
+import { Switch, View } from 'react-native'
+import Section from '@/components/ui/inputs/Section'
+import Text from '@/components/ui/MyText'
+import IconButton from '@/components/ui/IconButton'
+import XView from '@/components/ui/layout/XView'
+import useTheme from '@/contexts/theme'
+import i18n from '@/lib/locales'
+import { rowPaddingVertical } from '@/constants/Inputs'
+import {
+  getEffectiveScheduleScreenOrder,
+  type ScheduleScreenElementKey,
+} from '@/lib/scheduleScreenPreferences'
+import { usePreferences } from '@/stores/preferences'
+
+const ScheduleScreenPreferencesSection = () => {
+  const preferences = usePreferences()
+  const theme = useTheme()
+  const order = getEffectiveScheduleScreenOrder(
+    preferences.scheduleScreenElementsOrder
+  )
+
+  const move = (index: number, direction: -1 | 1) => {
+    const target = index + direction
+    if (target < 0 || target >= order.length) return
+    const next = [...order]
+    ;[next[index], next[target]] = [next[target], next[index]]
+    preferences.set({ scheduleScreenElementsOrder: next })
+  }
+
+  const setVisibility = (key: ScheduleScreenElementKey, value: boolean) => {
+    preferences.set((state) => ({
+      scheduleScreenElements: { ...state.scheduleScreenElements, [key]: value },
+    }))
+  }
+
+  return (
+    <Section>
+      <View
+        style={{
+          paddingRight: 20,
+          paddingVertical: rowPaddingVertical,
+          gap: 15,
+        }}
+      >
+        <Text style={{ fontFamily: theme.fonts.semiBold }}>
+          {i18n.t('sectionsVisibility')}
+        </Text>
+        <View style={{ paddingLeft: 20, gap: 12 }}>
+          {order.map((key, index) => (
+            <XView
+              key={key}
+              style={{ justifyContent: 'space-between', gap: 6 }}
+            >
+              <XView style={{ gap: 8 }}>
+                <IconButton
+                  icon={ArrowUp}
+                  onPress={index === 0 ? undefined : () => move(index, -1)}
+                  color={
+                    index === 0 ? theme.colors.border : theme.colors.textAlt
+                  }
+                  hitSlop={{ top: 10, bottom: 10, left: 10, right: 0 }}
+                />
+                <IconButton
+                  icon={ArrowDown}
+                  onPress={
+                    index === order.length - 1
+                      ? undefined
+                      : () => move(index, 1)
+                  }
+                  color={
+                    index === order.length - 1
+                      ? theme.colors.border
+                      : theme.colors.textAlt
+                  }
+                  hitSlop={{ top: 10, bottom: 10, left: 0, right: 10 }}
+                />
+              </XView>
+              <Text style={{ flex: 1, marginLeft: 8 }}>
+                {i18n.t('assistant.label')}
+              </Text>
+              <Switch
+                accessibilityLabel={i18n.t('assistant.label')}
+                value={preferences.scheduleScreenElements.assistant}
+                onValueChange={(value) => setVisibility(key, value)}
+              />
+            </XView>
+          ))}
+        </View>
+      </View>
+    </Section>
+  )
+}
+
+export default ScheduleScreenPreferencesSection

--- a/src/features/settings/screens/preferences/PreferencesScreen.tsx
+++ b/src/features/settings/screens/preferences/PreferencesScreen.tsx
@@ -64,6 +64,13 @@ const PreferencesScreen = () => {
             >
               <IconButton icon={ChevronRightIcon} />
             </InputRowButton>
+            <InputRowButton
+              leftIcon={Calendar1Icon}
+              label={i18n.t('milestoneSecondary_schedule_title')}
+              onPress={() => navigation.navigate('PreferencesScheduleScreen')}
+            >
+              <IconButton icon={ChevronRightIcon} />
+            </InputRowButton>
             {Platform.OS === 'ios' && (
               <InputRowButton
                 leftIcon={LayoutGridIcon}

--- a/src/features/settings/screens/preferences/screens/PreferencesScheduleScreen.tsx
+++ b/src/features/settings/screens/preferences/screens/PreferencesScheduleScreen.tsx
@@ -1,0 +1,17 @@
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
+import Wrapper from '@/components/ui/layout/Wrapper'
+import ScheduleScreenPreferencesSection from '@/features/settings/components/preferences-sections/ScheduleScreenPreferencesSection'
+
+const PreferencesScheduleScreen = () => {
+  return (
+    <Wrapper insets='bottom'>
+      <KeyboardAwareScrollView
+        contentContainerStyle={{ gap: 30, paddingTop: 30, paddingBottom: 30 }}
+      >
+        <ScheduleScreenPreferencesSection />
+      </KeyboardAwareScrollView>
+    </Wrapper>
+  )
+}
+
+export default PreferencesScheduleScreen

--- a/src/lib/scheduleScreenPreferences.ts
+++ b/src/lib/scheduleScreenPreferences.ts
@@ -1,0 +1,15 @@
+export type ScheduleScreenElementKey = 'assistant'
+export const DEFAULT_SCHEDULE_SCREEN_ELEMENTS_ORDER: ScheduleScreenElementKey[] =
+  ['assistant']
+
+export function getEffectiveScheduleScreenOrder(
+  stored: string[] | undefined
+): ScheduleScreenElementKey[] {
+  return [
+    ...new Set([...(stored ?? []), ...DEFAULT_SCHEDULE_SCREEN_ELEMENTS_ORDER]),
+  ].filter((key): key is ScheduleScreenElementKey =>
+    DEFAULT_SCHEDULE_SCREEN_ELEMENTS_ORDER.includes(
+      key as ScheduleScreenElementKey
+    )
+  )
+}

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_SCHEDULE_SCREEN_ELEMENTS_ORDER } from '@/lib/scheduleScreenPreferences'
 import { create } from 'zustand'
 import { persist, combine, createJSONStorage } from 'zustand/middleware'
 import { Publisher, PublisherHours } from '@/types/publisher'
@@ -412,6 +413,8 @@ export const PREFERENCE_DEFAULTS = {
    * device locale.
    */
   defaultPhoneRegionCode: null as string | null,
+  scheduleScreenElements: { assistant: true },
+  scheduleScreenElementsOrder: DEFAULT_SCHEDULE_SCREEN_ELEMENTS_ORDER,
   homeScreenElements: {
     approachingConversations: true,
     monthlyRoutine: true,

--- a/src/types/rootStack.ts
+++ b/src/types/rootStack.ts
@@ -37,6 +37,7 @@ export type RootStackParamList = {
   PreferencesPlans: undefined
   PreferencesNavigation: undefined
   PreferencesHomeScreen: undefined
+  PreferencesScheduleScreen: undefined
   PreferencesBackups: undefined
   PreferencesAppearance: undefined
   PreferencesPersonalization: undefined


### PR DESCRIPTION
Users who dismissed the calendar Assistant had no way to restore it. Add **Settings → Preferences → Schedule Screen**, following the Home Screen preferences layout, with an Assistant visibility switch and persisted section order. Assistant is the only configurable section, so both reorder arrows are disabled for now.

Calendar Assistant visibility uses only the new preference, which defaults to visible. Previous dismissals are intentionally ignored, so the Assistant reappears for existing users; they can dismiss it again or hide it in settings. Dismissing turns off the preference, and enabling the switch restores it. Existing goal/month/recommendation eligibility still applies. The calendar renders configurable sections in their saved order. Labels reuse existing approved translations.

Validation:
- `pnpm run testFinal`: 88 files, 1,202 tests passed.
- `pnpm run lint` and `pnpm run typecheck`: passed.
- Locale completeness passed with no locale changes.
- Native iOS visual verification was not run.
